### PR TITLE
kernel: Fix pure evaluation

### DIFF
--- a/nix/m1-support/kernel/package.nix
+++ b/nix/m1-support/kernel/package.nix
@@ -6,9 +6,12 @@
     }
   else pkgs;
 
-  # we do this so the config can be read on any system and not affect
-  # the output hash
-  localPkgs = import (pkgs.path) { system = builtins.currentSystem; };
+  localPkgs =
+    # we do this so the config can be read on any system and not affect
+    # the output hash
+    if builtins ? currentSystem then import (pkgs.path) { system = builtins.currentSystem; }
+    else pkgs;
+
   readConfig = configfile: import (localPkgs.runCommand "config.nix" {} ''
     echo "{" > "$out"
     while IFS='=' read key val; do


### PR DESCRIPTION
This fixes usage in pure evaluation mode (i.e., flakes) and doesn't affect any existing use-cases.