### PR TITLE
Expose m1n1 via system.build

### DIFF
--- a/nix/m1-support/boot-m1n1/default.nix
+++ b/nix/m1-support/boot-m1n1/default.nix
@@ -34,6 +34,7 @@ in {
 
     # ensure the installer has m1n1 in the image
     system.extraDependencies = lib.mkForce [ bootM1n1 bootUBoot ];
+    system.build.m1n1 = bootFiles."m1n1/boot.bin";
 
     # give the user the utilities to re-extract the firmware if necessary
     environment.systemPackages = [


### PR DESCRIPTION
This helped me debugging the build as there was no need to build the entire system, just m1n1