### PR TITLE
u-boot: Fix system detection

### DIFF
--- a/nix/m1-support/u-boot/default.nix
+++ b/nix/m1-support/u-boot/default.nix
@@ -6,7 +6,7 @@
 }: let
   # u-boot's buildInputs get a different hash and don't build right if we try to
   # cross-build for aarch64 on itself for whatever reason
-  buildPkgs = if pkgs.system == "aarch64-linux" then pkgs else pkgsCross.aarch64-multiplatform;
+  buildPkgs = if pkgs.stdenv.system == "aarch64-linux" then pkgs else pkgsCross.aarch64-multiplatform;
 in (buildPkgs.buildUBoot rec {
   src = fetchFromGitHub {
     # tracking: https://github.com/AsahiLinux/PKGBUILDs/blob/main/uboot-asahi/PKGBUILD


### PR DESCRIPTION
`system` is an attribute in `pkgs.stdenv`, not `pkgs`