### PR TITLE
Pass `boot.kernelPatches` to the kernel package

### DIFF
--- a/nix/m1-support/kernel/default.nix
+++ b/nix/m1-support/kernel/default.nix
@@ -4,6 +4,7 @@
 {
   config = {
     boot.kernelPackages = config.hardware.asahi.pkgs.callPackage ./package.nix {
+      inherit (config.boot) kernelPatches;
       _4KBuild = config.hardware.asahi.use4KPages;
     };
 

--- a/nix/m1-support/kernel/package.nix
+++ b/nix/m1-support/kernel/package.nix
@@ -6,13 +6,13 @@
     else pkgs;
 
   readConfig = configfile: import (localPkgs.runCommand "config.nix" { } ''
-    echo "{" > "$out"
+    echo "{ } // " > "$out"
     while IFS='=' read key val; do
       [ "x''${key#CONFIG_}" != "x$key" ] || continue
       no_firstquote="''${val#\"}";
-      echo '  "'"$key"'" = "'"''${no_firstquote%\"}"'";' >> "$out"
+      echo '{  "'"$key"'" = "'"''${no_firstquote%\"}"'"; } //' >> "$out"
     done < "${configfile}"
-    echo "}" >> $out
+    echo "{ }" >> $out
   '').outPath;
 
   linux_asahi_pkg = { stdenv, lib, fetchFromGitHub, fetchpatch, linuxKernel, ... } @ args:


### PR DESCRIPTION
... to make tinkering with the kernel configs and custom patches as simple as following the [wiki](https://nixos.wiki/wiki/Linux_kernel).

I also modified the `readConfig` function a little bit to make it allow config overrides, by basically just build the Nix expression from `//`-ing single-property sets.

Feel free to edit my branch as you need, I might not be around to reply to change requests.