### PR TITLE
several small changes

### DIFF
--- a/nix/installer-bootstrap/installer-configuration.nix
+++ b/nix/installer-bootstrap/installer-configuration.nix
@@ -65,11 +65,14 @@
     pkgs.gptfdisk
     pkgs.parted
     pkgs.cryptsetup
+    pkgs.wget
+    pkgs.curl
+    pkgs.magic-wormhole
   ];
 
-  # save space and compilation time. might revise?
-  hardware.enableAllFirmware = lib.mkForce false;
-  hardware.enableRedistributableFirmware = lib.mkForce false;
+  # add in firmware so usb-ethernet adapters work
+  hardware.enableAllFirmware = lib.mkForce true;
+  hardware.enableRedistributableFirmware = lib.mkForce true;
   sound.enable = false;
   # avoid including non-reproducible dbus docs
   documentation.doc.enable = false;

--- a/nix/m1-support/m1n1/default.nix
+++ b/nix/m1-support/m1n1/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , pkgsCross
 , python3
 , dtc
@@ -25,16 +26,25 @@ let
   });
 in stdenv.mkDerivation rec {
   pname = "m1n1";
-  version = "1.2.2";
+  version = "1.2.3";
 
   src = fetchFromGitHub {
     # tracking: https://github.com/AsahiLinux/PKGBUILDs/blob/stable/m1n1/PKGBUILD
     owner = "AsahiLinux";
     repo = "m1n1";
     rev = "v${version}";
-    hash = "sha256-KbiFE0eg/w/GcDRXSPysy1MMC3gcLyKRasal+lbIsdo=";
+    hash = "sha256-HEhsg3/OkMvAHvu16VFun87SNBPin69CL6XllE7sb4g=";
     fetchSubmodules = true;
   };
+  
+  # disable m1n1's silent mode and let it spew text to the screen
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/zzywysm/m1n1/commit/a3def19ba1c10ada0eeea1abc6e8d945dcb4f669.patch";
+      sha256 = "sha256-BjvV28ka/gMDJ2yalLTdim7gqm6VMlycy2lXe2u2nJk=";
+      revert = false;
+    }) 
+  ];
 
   makeFlags = [ "ARCH=aarch64-unknown-linux-gnu-" ]
     ++ lib.optional isRelease "RELEASE=1"

--- a/nix/m1-support/u-boot/default.nix
+++ b/nix/m1-support/u-boot/default.nix
@@ -21,11 +21,11 @@ in (buildPkgs.buildUBoot rec {
   extraMeta.platforms = [ "aarch64-linux" ];
   filesToInstall = [
     "u-boot-nodtb.bin.gz"
-    "m1n1-u-boot.macho"
     "m1n1-u-boot.bin"
   ];
   extraConfig = ''
     CONFIG_IDENT_STRING=" ${version}"
+    CONFIG_VIDEO_LOGO=n
   '';
 }).overrideAttrs (o: {
   # nixos's downstream patches are not applicable
@@ -34,7 +34,6 @@ in (buildPkgs.buildUBoot rec {
   preInstall = ''
     # compress so that m1n1 knows U-Boot's size and can find things after it
     gzip -n u-boot-nodtb.bin
-    cat ${m1n1}/build/m1n1.macho arch/arm/dts/t[68]*.dtb u-boot-nodtb.bin.gz > m1n1-u-boot.macho
     cat ${m1n1}/build/m1n1.bin arch/arm/dts/t[68]*.dtb u-boot-nodtb.bin.gz > m1n1-u-boot.bin
   '';
 })


### PR DESCRIPTION
- update m1n1 to 1.2.3
- let m1n1 spew output to the screen
- stop showing the u-boot logo
- remove the unnecessary m1n1-u-boot.macho file that's been irrelevant since macOS 12.1
- add more functionality to the installer