### PR TITLE
Improvements 2022-12-2

### DIFF
--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -66,7 +66,7 @@ Change directories to the repository, then use Nix to build m1n1 and symlink the
 nixos-m1$ nix-build -A m1n1 -o m1n1
 ```
 
-m1n1 has been built and the `.macho` and `.bin` files are now in `m1n1/build/`. You can also run m1n1's scripts such as `chainload.py` using a command like `m1n1/bin/m1n1-chainload`.
+m1n1 has been built and the build products are now in `m1n1/build/`. You can also run m1n1's scripts such as `chainload.py` using a command like `m1n1/bin/m1n1-chainload`.
 
 #### U-Boot
 
@@ -78,7 +78,7 @@ Use Nix to build U-Boot along with m1n1 and the device trees:
 nixos-m1$ nix-build -A u-boot -o u-boot
 ```
 
-The `.macho` and `.bin` files with m1n1, the device trees, and U-Boot joined together are now in `u-boot/`.
+The `.bin` file with m1n1, the device trees, and U-Boot joined together is now in `u-boot/`.
 
 #### Kernel and Bootstrap Installer
 
@@ -286,7 +286,7 @@ By selecting the appropriate menu option in the Asahi Linux installer, you can a
 To run U-Boot under the hypervisor, start m1n1 and attach the Mac to the host PC using an appropriate USB cable, change directories to the repo, then run:
 
 ```
-nixos-m1$ m1n1/bin/m1n1-run_guest u-boot/m1n1-u-boot.macho
+nixos-m1$ m1n1/bin/m1n1-run_guest --raw u-boot/m1n1-u-boot.bin
 ```
 
 To access the serial console, in a separate terminal run:

--- a/nix/installer-bootstrap/installer-configuration.nix
+++ b/nix/installer-bootstrap/installer-configuration.nix
@@ -65,6 +65,9 @@
     pkgs.gptfdisk
     pkgs.parted
     pkgs.cryptsetup
+    pkgs.curl
+    pkgs.wget
+    pkgs.wormhole-william
   ];
 
   # save space and compilation time. might revise?

--- a/nix/m1-support/kernel/default.nix
+++ b/nix/m1-support/kernel/default.nix
@@ -70,6 +70,9 @@
     # U-Boot does not support EFI variables
     boot.loader.efi.canTouchEfiVariables = lib.mkForce false;
 
+    # U-Boot does not support switching console mode
+    boot.loader.systemd-boot.consoleMode = "0";
+
     # GRUB has to be installed as removable if the user chooses to use it
     boot.loader.grub = lib.mkDefault {
       version = 2;

--- a/nix/m1-support/m1n1/default.nix
+++ b/nix/m1-support/m1n1/default.nix
@@ -70,7 +70,6 @@ in stdenv.mkDerivation rec {
     runHook preInstall
 
     mkdir -p $out/build
-    cp build/m1n1.macho $out/build
     cp build/m1n1.bin $out/build
   '' + (lib.optionalString withTools ''
     mkdir -p $out/{bin,script,toolchain-bin}

--- a/nix/m1-support/u-boot/default.nix
+++ b/nix/m1-support/u-boot/default.nix
@@ -21,7 +21,6 @@ in (buildPkgs.buildUBoot rec {
   extraMeta.platforms = [ "aarch64-linux" ];
   filesToInstall = [
     "u-boot-nodtb.bin.gz"
-    "m1n1-u-boot.macho"
     "m1n1-u-boot.bin"
   ];
   extraConfig = ''
@@ -34,7 +33,6 @@ in (buildPkgs.buildUBoot rec {
   preInstall = ''
     # compress so that m1n1 knows U-Boot's size and can find things after it
     gzip -n u-boot-nodtb.bin
-    cat ${m1n1}/build/m1n1.macho arch/arm/dts/t[68]*.dtb u-boot-nodtb.bin.gz > m1n1-u-boot.macho
     cat ${m1n1}/build/m1n1.bin arch/arm/dts/t[68]*.dtb u-boot-nodtb.bin.gz > m1n1-u-boot.bin
   '';
 })

--- a/nix/m1-support/u-boot/default.nix
+++ b/nix/m1-support/u-boot/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, fetchpatch
 , pkgs
 , pkgsCross
 , m1n1
@@ -25,10 +26,28 @@ in (buildPkgs.buildUBoot rec {
   ];
   extraConfig = ''
     CONFIG_IDENT_STRING=" ${version}"
+    CONFIG_VIDEO_FONT_4X6=n
+    CONFIG_VIDEO_FONT_8X16=n
+    CONFIG_VIDEO_FONT_SUN12X22=n
+    CONFIG_VIDEO_FONT_TER12X24=n
+    CONFIG_VIDEO_FONT_TER16X32=y
   '';
 }).overrideAttrs (o: {
   # nixos's downstream patches are not applicable
-  patches = [ ];
+  # however, we add in bigger u-boot fonts because the mac laptop screens are high-res
+  patches = [ 
+    (fetchpatch {
+      url = "https://git.alpinelinux.org/aports/plain/testing/u-boot-asahi/apritzel-first5-video.patch?id=990110f35b50b74bdb4e902d94fa15b07a8eac9e";
+      sha256 = "sha256-QPvJYxIcQBHbwsj7l96qGUZSipk1sB3ZyniD1Io18dY=";
+      revert = false;
+    })
+
+    (fetchpatch {
+      url = "https://git.alpinelinux.org/aports/plain/testing/u-boot-asahi/mps-u-boot-ter12x24.patch?id=990110f35b50b74bdb4e902d94fa15b07a8eac9e";
+      sha256 = "sha256-wrQpIYiuNRi/p2p290KCGPmuRxFEOPlbICoFvd+E8p0=";
+      revert = false;
+    })
+  ];
 
   preInstall = ''
     # compress so that m1n1 knows U-Boot's size and can find things after it


### PR DESCRIPTION
Small fixes and changes:
- Stop caring about the m1n1 mach-o binary
- Add curl, wget, and wormhole-william to the installer environment to make it easier to copy files
- Fix the "Error switching console mode" bug
- Increase the size of the u-boot font, which makes the NixOS generation picker readable

Previous review comments at https://github.com/tpwrules/nixos-m1/pull/32