### PR TITLE
Cosmetics 2022 12

### DIFF
--- a/nix/m1-support/m1n1/default.nix
+++ b/nix/m1-support/m1n1/default.nix
@@ -36,6 +36,8 @@ in stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [ ./spew.patch ];
+
   makeFlags = [ "ARCH=aarch64-unknown-linux-gnu-" ]
     ++ lib.optional isRelease "RELEASE=1"
     ++ lib.optional withChainloading "CHAINLOADING=1";

--- a/nix/m1-support/m1n1/spew.patch
+++ b/nix/m1-support/m1n1/spew.patch
@@ -1,0 +1,25 @@
+From a3def19ba1c10ada0eeea1abc6e8d945dcb4f669 Mon Sep 17 00:00:00 2001
+From: Zzy Wysm <zzy@zzywysm.com>
+Date: Fri, 9 Dec 2022 14:28:04 -0500
+Subject: [PATCH] zzy m1n1 customizations
+
+i like boot scroll and faster boots
+---
+ config.h | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/config.h b/config.h
+index 7ba015662..3712e0ad2 100644
+--- a/config.h
++++ b/config.h
+@@ -20,9 +20,8 @@
+ //#define TARGET T8103
+ 
+ #ifdef RELEASE
+-# define FB_SILENT_MODE
+ # ifdef CHAINLOADING
+-#  define EARLY_PROXY_TIMEOUT 5
++#  define EARLY_PROXY_TIMEOUT 2
+ # endif
+ #endif
+ 

--- a/nix/m1-support/u-boot/default.nix
+++ b/nix/m1-support/u-boot/default.nix
@@ -26,6 +26,7 @@ in (buildPkgs.buildUBoot rec {
   ];
   extraConfig = ''
     CONFIG_IDENT_STRING=" ${version}"
+    CONFIG_VIDEO_LOGO=n
     CONFIG_VIDEO_FONT_4X6=n
     CONFIG_VIDEO_FONT_8X16=n
     CONFIG_VIDEO_FONT_SUN12X22=n


### PR DESCRIPTION
These are two changes to how the boot process looks on screen.  They are ultimately a matter of taste, but I offer this pull request in case your tastes match mine.

- We enable m1n1's console output to the screen.  It flies by quickly, but I think it looks good.
- We disable u-boot's graphical logo in the upper-right corner of the screen.