### PR TITLE
Override mesa globally to make all packages use the asahi mesa

### DIFF
--- a/nix/m1-support/mesa/default.nix
+++ b/nix/m1-support/mesa/default.nix
@@ -1,9 +1,17 @@
 { config, pkgs, lib, ... }:
 {
   config = let
-    mesaAsahi = pkgs.callPackage ./package.nix { };
+    mesaAsahi = pkgs: pkgs.callPackage ./package.nix { mesa = pkgs.mesa; };
   in lib.mkIf config.hardware.asahi.useExperimentalGPUDriver {
-    hardware.opengl.package = mesaAsahi.drivers;
+    # Every package that references mesa should use the asahi mesa package.
+    # This is for example required to make plasma wayland working, as otherwise
+    # it would use the wrong mesa libraries.
+    nixpkgs.config.packageOverrides = pkgs: {
+      mesa = (mesaAsahi pkgs);
+    };
+
+    # As we override the mesa pkg in the "global" packages, we can reference mesa here directly
+    hardware.opengl.package = pkgs.mesa.drivers;
 
     # required for GPU kernel driver
     hardware.asahi.addEdgeKernelConfig = true;


### PR DESCRIPTION
This is required to make plasma wayland working. Otherwise it would reference the normal mesa libraries and they don't work with asahi gpu driver ;)

Closes: #45 