### PR TITLE
peripheral-firmware: Allow using pkgs.requireFile

### DIFF
--- a/nix/m1-support/peripheral-firmware/default.nix
+++ b/nix/m1-support/peripheral-firmware/default.nix
@@ -21,7 +21,7 @@
 
         buildCommand = ''
           mkdir extracted
-          asahi-fwextract ${/. + config.hardware.asahi.peripheralFirmwareDirectory} extracted
+          asahi-fwextract ${config.hardware.asahi.peripheralFirmwareDirectory} extracted
 
           mkdir -p $out/lib/firmware
           cat extracted/firmware.cpio | cpio -id --quiet --no-absolute-filenames
@@ -54,7 +54,9 @@
         validPaths = (builtins.filter
           (p: builtins.pathExists (p + "/all_firmware.tar.gz"))
           paths) ++ [ null ];
-      in builtins.elemAt validPaths 0;
+
+        firstPath = builtins.elemAt validPaths 0;
+      in if firstPath != null then "${/. + firstPath}" else null;
       description = ''
         Path to the directory containing the non-free non-redistributable
         peripheral firmware necessary for features like Wi-Fi. Ordinarily, this


### PR DESCRIPTION
I think this is correct. This fixes the issue where pkgs.requireFile cannot be used for the firmware directory. The root cause is that ./ + does not work for store paths