### PR TITLE
drop systemd.package ad-hoc patching

### DIFF
--- a/apple-silicon-support/modules/default.nix
+++ b/apple-silicon-support/modules/default.nix
@@ -13,29 +13,6 @@
     in lib.mkIf cfg.enable {
       nixpkgs.overlays = lib.mkBefore [ cfg.overlay ];
 
-      # patch systemd-boot to boot in Apple Silicon UEFI environment.
-      # This regression only appeared in systemd 256.7.
-      # see https://github.com/NixOS/nixpkgs/pull/355290
-      # and https://github.com/systemd/systemd/issues/35026
-      systemd.package = let
-        systemdBroken = (pkgs.systemd.version == "256.7");
-
-        systemdPatched = pkgs.systemd.overrideAttrs (old: {
-          patches = let
-            oldPatches = (old.patches or []);
-            # not sure why there are non-paths in there but oh well
-            patchNames = (builtins.map (p: if ((builtins.typeOf p) == "path") then builtins.baseNameOf p else "") oldPatches);
-            fixName = "0019-Revert-boot-Make-initrd_prepare-semantically-equival.patch";
-            alreadyPatched = builtins.elem fixName patchNames;
-          in oldPatches ++ lib.optionals (!alreadyPatched) [
-            (pkgs.fetchpatch {
-              url = "https://raw.githubusercontent.com/NixOS/nixpkgs/125e99477b0ac0a54b7cddc6c5a704821a3074c7/pkgs/os-specific/linux/systemd/${fixName}";
-              hash = "sha256-UW3DZiaykQUUNcGA5UFxN+/wgNSW3ufxDDCZ7emD16o=";
-            })
-          ];
-        });
-      in if systemdBroken then systemdPatched else pkgs.systemd;
-
       hardware.asahi.pkgs =
         if cfg.pkgsSystem != "aarch64-linux"
         then


### PR DESCRIPTION
Both the current stable nixpkgs release, as well as unstable are way past 256.7.

We can drop this workaround.