### PR TITLE
linux-asahi: Fix Rust support

### DIFF
--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -144,6 +144,11 @@ let
       config = configAttrs;
     };
 
-  linux-asahi = (callPackage linux-asahi-pkg { });
+  linux-asahi = (callPackage linux-asahi-pkg { }).overrideAttrs (_: {
+    # FIXME: Remove when https://github.com/NixOS/nixpkgs/pull/436245 lands
+    preConfigure = ''
+      export RUST_LIB_SRC KRUSTFLAGS
+    '';
+  });
 in
 lib.recurseIntoAttrs (linuxPackagesFor linux-asahi)


### PR DESCRIPTION
Add a hack to fix Rust support broken by NixOS/nixpkgs#423933

See NixOS/nixpkgs#436245 for Nixpkgs upstream fix
