### PR TITLE
include base.nix for more filesystems support

### DIFF
--- a/iso-configuration/installer-configuration.nix
+++ b/iso-configuration/installer-configuration.nix
@@ -15,6 +15,7 @@
 
 {
   imports = [
+    (modulesPath + "/profiles/base.nix")
     (modulesPath + "/profiles/minimal.nix")
     (modulesPath + "/profiles/installation-device.nix")
     (modulesPath + "/installer/cd-dvd/iso-image.nix")
@@ -69,14 +70,7 @@
 
   isoImage.squashfsCompression = "zstd -Xcompression-level 6";
 
-  environment.systemPackages = with pkgs; [
-    gptfdisk
-    parted
-    cryptsetup
-    curl
-    wget
-    wormhole-william
-  ];
+  environment.systemPackages = with pkgs; [ wormhole-william ];
 
   # save space and compilation time. might revise?
   hardware.enableAllFirmware = lib.mkForce false;
@@ -146,6 +140,11 @@
   boot.swraid.mdadmConf = ''
     PROGRAM ${pkgs.coreutils}/bin/true
   '';
+
+  # profiles/base.nix assumes the default LTS kernel, and thus enables ZFS.
+  # We do not use LTS kernel, thus disable ZFS to match latest-kernel specialisation
+  # and avoid breaking the installer image when ZFS does not build against our kernel.
+  boot.supportedFilesystems.zfs = false;
 
   # avoid error that flakes must be enabled when nixos-install uses <nixpkgs>
   nixpkgs.flake.setNixPath = false;


### PR DESCRIPTION
This is to match the capabilities (partitioning / formatting / rescue tools, filesystems...) generally provided in NixOS installer ISOs.
Note that minimal.nix and base.nix profiles do not contradict. base.nix adds new tools, while minimal.nix reduces the image size by disabling documentation etc.

Blocking:

~1. The ZFS implications of this need to be discussed~

As discussed with flokli, and [previously mentioned by tpwrules](https://github.com/nix-community/nixos-apple-silicon/issues/111#issuecomment-1773638064), we explicitly keep ZFS support disabled to avoid build failures and match the latest-kernel specialisation of the upstream ISOs. So this PR does not change anything about ZFS support.

~2. The next staging-next cycle (https://github.com/NixOS/nixpkgs/pull/444862) needs to be merged since this fixes bcache-tools in the cross iso~