### PR TITLE
linux-asahi: 6.17.5-1 -> 6.17.7-2

### DIFF
--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -18,15 +18,15 @@ let
       inherit stdenv lib;
 
       pname = "linux-asahi";
-      version = "6.17.5";
+      version = "6.17.7";
       modDirVersion = version;
       extraMeta.branch = "6.17";
 
       src = fetchFromGitHub {
         owner = "AsahiLinux";
         repo = "linux";
-        tag = "asahi-6.17.5-1";
-        hash = "sha256-kTYgIIl6R2pqh2hBKCDkZ4nxF0K1SfjeEmGWGrzwGtI=";
+        tag = "asahi-6.17.7-2";
+        hash = "sha256-wyuHcp9rEpOtNb8aRPkfX57XdcmpitklM4oew/YMRio=";
       };
 
       kernelPatches = [


### PR DESCRIPTION
According to jannau fixes a use-after-free in the kernel driver (unsure of when it was introduced).

This is also the current Fedora release.

Tested that it boots on 2020 Macbook Pro w/ M1 Max and seems to work okay.