### PR TITLE
.github: revamp installer CI

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -50,7 +50,10 @@ jobs:
         run: |
           # rest of the installer is downloaded and agglomerated and a few minor things are built
           nix build --extra-experimental-features 'nix-command flakes' .#installer-bootstrap -j2 -L
-          cp result/iso/*.iso $(basename result/iso/*.iso | sed s/aarch64-linux/apple-silicon-${{ github.ref_name }}/)
+
+          INSTALLER_DEST=$(basename result/iso/*.iso | sed 's:aarch64-linux:apple-silicon-${{ github.ref_name }}:' | tr '/' '-')
+          echo installer dest: "$INSTALLER_DEST"
+          cp result/iso/*.iso "$INSTALLER_DEST"
 
       - uses: actions/upload-artifact@v5
         with:


### PR DESCRIPTION
Big things:
* now built on ARM runner so the kernel is available for the user
* split up to reduce problems with running out of space or time
* doesn't use nix-community cache or builders, avoiding contamination

Tested that it boots and installs okay.

Build succeeded on my fork: https://github.com/tpwrules/my-nixos-apple-silicon/actions/runs/19211475096