### PR TITLE
modules: Remove Mesa version warning for >= 25.3.2

### DIFF
--- a/apple-silicon-support/modules/default.nix
+++ b/apple-silicon-support/modules/default.nix
@@ -31,11 +31,14 @@
 
       # 900 is higher priority than mkDefault but lower than just setting
       hardware.graphics.package = lib.mkOverride 900 (
-        lib.warnIf (lib.versionAtLeast pkgs.mesa.version "25.3") ''
-          Mesa 25.3 is known to cause crashes in Firefox on Asahi GPUs.
-          Please pin nixpkgs c5ae371f1a6a7fd27823 or earlier if affected.
-          See https://github.com/nix-community/nixos-apple-silicon/issues/380
-          for more info.'' pkgs.mesa
+        lib.warnIf
+          (lib.versionAtLeast pkgs.mesa.version "25.3" && lib.versionOlder pkgs.mesa.version "25.3.2")
+          ''
+            Mesa 25.3.0 and 25.3.1 are known to cause crashes in Firefox on Asahi
+            GPUs.  Please update to Mesa >= 25.3.2 by updating Nixpkgs.  See
+            https://github.com/nix-community/nixos-apple-silicon/issues/380 for
+            more info.''
+          pkgs.mesa
       );
     };
 


### PR DESCRIPTION
Closes #380

Or we could just remove this warning on next release.

Draft pending more testing on waiting for Mesa 25.3.2 to actually release