### PR TITLE
linux-asahi: 6.17.9-1 -> 6.17.11-1

### DIFF
--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -18,15 +18,15 @@ let
       inherit stdenv lib;
 
       pname = "linux-asahi";
-      version = "6.17.9";
+      version = "6.17.11";
       modDirVersion = version;
       extraMeta.branch = "6.17";
 
       src = fetchFromGitHub {
         owner = "AsahiLinux";
         repo = "linux";
-        tag = "asahi-6.17.9-1";
-        hash = "sha256-HYsBLCRzGALvc7lyaAZmO+liIxStYpuQ7UqmjwJzVjg=";
+        tag = "asahi-6.17.11-1";
+        hash = "sha256-bTptFNR7ehMdW3M05c0S6GZ4H19GCYvplso8zOkEnmQ=";
       };
 
       kernelPatches = [


### PR DESCRIPTION
https://github.com/AsahiLinux/linux/releases/tag/asahi-6.17.11-1

With this kernel version they fixed an issue on M2 Pro/Max chips where the microphone wouldn't work.