### PR TITLE
linux-asahi: 6.18.4-1 -> 6.18.5-1

### DIFF
--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -18,15 +18,15 @@ let
       inherit stdenv lib;
 
       pname = "linux-asahi";
-      version = "6.18.4";
+      version = "6.18.5";
       modDirVersion = version;
       extraMeta.branch = "6.18";
 
       src = fetchFromGitHub {
         owner = "AsahiLinux";
         repo = "linux";
-        tag = "asahi-6.18.4-1";
-        hash = "sha256-qWY74VJ5Kn2V/MdFlkgwQ5ILtTV5W8ibOw9zkBeu50E=";
+        tag = "asahi-6.18.5-1";
+        hash = "sha256-N3c0aFdR0DploWX3ydFCoSYDuYd48El8TdtLgKnI1cc=";
       };
 
       kernelPatches = [


### PR DESCRIPTION
https://github.com/AsahiLinux/linux/releases/tag/asahi-6.18.5-1

```
Tagging asahi-6.18.5-1

- rebase onto v6.18.5
- mark hibernation as unavailable
- update macsmc-power to handle smc 26.x fw
- add missing RUST_FW_ABSTRACTION dependency for aop_als
```