### PR TITLE
systemd-boot: remove forced `consoleMode = "0"`

### DIFF
--- a/apple-silicon-support/modules/kernel/default.nix
+++ b/apple-silicon-support/modules/kernel/default.nix
@@ -76,9 +76,6 @@
     # U-Boot does not support EFI variables
     boot.loader.efi.canTouchEfiVariables = lib.mkForce false;
 
-    # U-Boot does not support switching console mode
-    boot.loader.systemd-boot.consoleMode = "0";
-
     # GRUB has to be installed as removable if the user chooses to use it
     boot.loader.grub = lib.mkDefault {
       efiSupport = true;


### PR DESCRIPTION
Setting `consoleMode = lib.mkForce "max"` seemed to work perfectly fine, and this comment/line was added in 2022, which means u-boot has possibly been updated since then to allow for this.