### PR TITLE
Add limine support

### DIFF
--- a/apple-silicon-support/modules/boot-m1n1/default.nix
+++ b/apple-silicon-support/modules/boot-m1n1/default.nix
@@ -36,6 +36,7 @@ in
     # install m1n1 with the boot loader
     boot.loader.grub.extraFiles = bootFiles;
     boot.loader.systemd-boot.extraFiles = bootFiles;
+    boot.loader.limine.additionalFiles = bootFiles;
 
     # ensure the installer has m1n1 in the image
     system.extraDependencies = lib.mkForce [


### PR DESCRIPTION
Limine support 👍

From [search.nixos.org](https://search.nixos.org/options?channel=unstable&query=boot.loader.limine.&show=boot.loader.limine.additionalFiles):
> [boot.loader.limine.additionalFiles](https://search.nixos.org/options?channel=unstable&query=boot.loader.limine.&show=boot.loader.limine.additionalFiles)
> Name: boot.loader.limine.additionalFiles
> Description:
> A set of files to be copied to /boot. Each attribute name denotes the destination file name in /boot, while the corresponding attribute value specifies the source file.
> Type: attribute set of absolute path
> Default: { }
> Example: `{ "efi/memtest86/memtest86.efi" = "${pkgs.memtest86-efi}/BOOTX64.efi"; }`
> Declared in: [nixos/modules/system/boot/loader/limine/limine.nix](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/modules/system/boot/loader/limine/limine.nix)