### PR TITLE
docs/uefi-standalone, installer: enable Network Manager, and make it use IWD for wireless connectivity

### DIFF
--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -274,14 +274,6 @@ Some keyboard layouts are not detected correctly. On some devices, the \` key is
 networking.networkmanager.backend = "iwd";
 ```
 
-> [!TIP] Using iwd in your fully installed system
->
-> By default, NixOS uses resolvconf for DNS, but iwd's default is systemd-resolved. Ensure it's set to use your DNS subsystem of choice:
-> ```nix
-> # Supports "resolvconf" and "systemd"
-> networking.wireless.iwd.settings.Network.NameResolvingService = "resolvconf";
-> ```
-
 If you have a MacBook model that has a [touchbar](https://support.apple.com/guide/mac-help/use-the-touch-bar-mchlbfd5b039/mac), you will also have to add this to your configuration to ensure that graphical sessions render on the main display and not within the touchbar itself:
 
 ```nix

--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -270,7 +270,7 @@ Some keyboard layouts are not detected correctly. On some devices, the \` key is
 
 `iwd` is recommended for WiFi on most systems:
 ```nix
-# Implicitly disables wpa_supplicant
+# Implicitly enables IWD and disables wpa_supplicant
 networking.networkmanager.backend = "iwd";
 ```
 

--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -270,10 +270,8 @@ Some keyboard layouts are not detected correctly. On some devices, the \` key is
 
 `iwd` is recommended for WiFi on most systems:
 ```nix
-networking.wireless.iwd = {
-  enable = true;
-  settings.General.EnableNetworkConfiguration = true;
-};
+# Implicitly disables wpa_supplicant
+networking.networkmanager.backend = "iwd";
 ```
 
 > [!TIP] Using iwd in your fully installed system
@@ -282,12 +280,6 @@ networking.wireless.iwd = {
 > ```nix
 > # Supports "resolvconf" and "systemd"
 > networking.wireless.iwd.settings.Network.NameResolvingService = "resolvconf";
-> ```
->
-> If you will be using NetworkManager:
-> ```nix
-> # Allows iwd to be configured by your desktop environment's settings program
-> networking.networkmanager.backend = "iwd";
 > ```
 
 If you have a MacBook model that has a [touchbar](https://support.apple.com/guide/mac-help/use-the-touch-bar-mchlbfd5b039/mac), you will also have to add this to your configuration to ensure that graphical sessions render on the main display and not within the touchbar itself:

--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -269,11 +269,23 @@ Some keyboard layouts are not detected correctly. On some devices, the \` key is
  ```
 
 `iwd` is recommended for WiFi on most systems:
-```
+```nix
 networking.wireless.iwd = {
   enable = true;
   settings.General.EnableNetworkConfiguration = true;
 };
+```
+
+By default, NixOS uses resolvconf for DNS, but iwd's default is systemd-resolved. Ensure it's set to use your DNS subsystem of choice:
+```nix
+# Supports "resolvconf" and "systemd"
+networking.wireless.iwd.settings.Network.NameResolvingService = "resolvconf";
+```
+
+If you intend to use `iwd` with NetworkManager:
+```nix
+# Allows iwd to be configured by your desktop environment's settings program
+networking.networkmanager.backend = "iwd";
 ```
 
 If you have a MacBook model that has a [touchbar](https://support.apple.com/guide/mac-help/use-the-touch-bar-mchlbfd5b039/mac), you will also have to add this to your configuration to ensure that graphical sessions render on the main display and not within the touchbar itself:

--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -276,17 +276,19 @@ networking.wireless.iwd = {
 };
 ```
 
-By default, NixOS uses resolvconf for DNS, but iwd's default is systemd-resolved. Ensure it's set to use your DNS subsystem of choice:
-```nix
-# Supports "resolvconf" and "systemd"
-networking.wireless.iwd.settings.Network.NameResolvingService = "resolvconf";
-```
-
-If you intend to use `iwd` with NetworkManager:
-```nix
-# Allows iwd to be configured by your desktop environment's settings program
-networking.networkmanager.backend = "iwd";
-```
+> [!TIP] Using iwd in your fully installed system
+>
+> By default, NixOS uses resolvconf for DNS, but iwd's default is systemd-resolved. Ensure it's set to use your DNS subsystem of choice:
+> ```nix
+> # Supports "resolvconf" and "systemd"
+> networking.wireless.iwd.settings.Network.NameResolvingService = "resolvconf";
+> ```
+>
+> If you will be using NetworkManager:
+> ```nix
+> # Allows iwd to be configured by your desktop environment's settings program
+> networking.networkmanager.backend = "iwd";
+> ```
 
 If you have a MacBook model that has a [touchbar](https://support.apple.com/guide/mac-help/use-the-touch-bar-mchlbfd5b039/mac), you will also have to add this to your configuration to ensure that graphical sessions render on the main display and not within the touchbar itself:
 

--- a/iso-configuration/installer-configuration.nix
+++ b/iso-configuration/installer-configuration.nix
@@ -85,28 +85,15 @@
   hardware.asahi.setupAsahiSound = false;
   system.extraDependencies = lib.mkForce [ ];
 
-  # Disable wpa_supplicant because it can't use WPA3-SAE on broadcom chips that are used on macs and it is harder to use and less mainained than iwd in general
-  networking.wireless.enable = false;
-  # Enable iwd
+  # Enable iwd and make NetworkManager, enabled by default, use iwd for wifi
+  # We use iwd instead of wpa_supplicant because it can't use WPA3-SAE on broadcom chips that are used on macs,
+  # and it is harder to use and less mainained than iwd in general
+  networking.networkmanager.wifi.backend = "iwd";
+
   networking.wireless.iwd = {
-    enable = true;
-    settings.General.EnableNetworkConfiguration = true;
     # NixOS by default uses resolvconf for DNS, but iwd's default is systemd-resolved. Make iwd use resolvconf
     settings.Network.NameResolvingService = "resolvconf";
   };
-  # Make sure NetworkManager, also enabled by default, uses iwd for wifi
-  networking.networkmanager.wifi.backend = "iwd";
-
-  # let user know to use iwctl to get access to iwd
-  services.getty.helpLine = lib.mkForce ''
-    The "nixos" and "root" accounts have empty passwords.
-
-    To log in over ssh you must set a password for either "nixos" or "root"
-    with `passwd` (prefix with `sudo` for "root"), or add your public key to
-    /home/nixos/.ssh/authorized_keys or /root/.ssh/authorized_keys.
-
-    To set up a wireless connection, run `iwctl`.
-  '';
 
   nixpkgs.overlays =
     lib.optionals (config.nixpkgs.hostPlatform.system != config.nixpkgs.buildPlatform.system)

--- a/iso-configuration/installer-configuration.nix
+++ b/iso-configuration/installer-configuration.nix
@@ -90,11 +90,6 @@
   # and it is harder to use and less mainained than iwd in general
   networking.networkmanager.wifi.backend = "iwd";
 
-  networking.wireless.iwd = {
-    # NixOS by default uses resolvconf for DNS, but iwd's default is systemd-resolved. Make iwd use resolvconf
-    settings.Network.NameResolvingService = "resolvconf";
-  };
-
   nixpkgs.overlays =
     lib.optionals (config.nixpkgs.hostPlatform.system != config.nixpkgs.buildPlatform.system)
       [

--- a/iso-configuration/installer-configuration.nix
+++ b/iso-configuration/installer-configuration.nix
@@ -91,8 +91,11 @@
   networking.wireless.iwd = {
     enable = true;
     settings.General.EnableNetworkConfiguration = true;
+    # NixOS by default uses resolvconf for DNS, but iwd's default is systemd-resolved. Make iwd use resolvconf
+    settings.Network.NameResolvingService = "resolvconf";
   };
-  networking.networkmanager.enable = lib.mkForce false;
+  # Make sure NetworkManager, also enabled by default, uses iwd for wifi
+  networking.networkmanager.wifi.backend = "iwd";
 
   # let user know to use iwctl to get access to iwd
   services.getty.helpLine = lib.mkForce ''


### PR DESCRIPTION
This PR has evolved significantly since I originally created it. What started as me adding some info I found regarding DNS and IWD, is now enabling Network Manager in the installer and making it work with IWD. This brings the installer and documentation closer in-line with the standard NixOS installer. 

---

Hey there!

## Summary

This PR adds a few lines to `docs/uefi-standalone.md` regarding making IWD, NetworkManager, and the user's DNS system of choice, all correctly connect with each other.

It also implements these recommendations in `iso-configuration/installer-configuration.nix`.

## Context

I was having a bunch of trouble getting my machine to use an alternate DNS server, with no success using Plasma Settings via Network Manager or using something like `networking.nameservers = [ "10.0.0.6" ];`. Finally, after much troubleshooting, I discovered that [IWD uses `systemd-resolved`](https://man.archlinux.org/man/iwd.config.5#Network) by default, while [NixOS uses `resolvconf`](https://nixos.org/manual/nixos/stable/options#opt-networking.resolvconf.enable) by default. After setting IWD to use resolvconf, I was finally able to set my alternate DNS server in Plasma Settings.

## Future work

It would make sense for NetworkManager to automatically use IWD as its wireless backend when enabled, and for IWD to automatically use the user's configured DNS client (if compatible, and asserting when not), but that is work that should be done in nixpkgs.