### PR TITLE
Change default option for Asahi Linux support to false

### DIFF
--- a/apple-silicon-support/modules/default.nix
+++ b/apple-silicon-support/modules/default.nix
@@ -45,7 +45,7 @@
   options.hardware.asahi = {
     enable = lib.mkOption {
       type = lib.types.bool;
-      default = true;
+      default = false;
       description = ''
         Enable the basic Asahi Linux components, such as kernel and boot setup.
       '';


### PR DESCRIPTION
This change would make it so that users with multi-machine configurations don't need to guard against this module, only to re-enable the option later for the machine that actually needs it, eg.

```nix
# flake.nix
nixosModules.asahi = { config, lib, ... }: {
  imports = [ nixos-apple-silicon.nixosModules.default ];
  config.nixpkgs.overlays = [ nixos-apple-silicon.overlays.default ];
  config.hardware.asahi.enable = lib.mkDefault false;
};
```
```nix
# configuration.nix
hardware.asahi.enable = true;
```

The only change current users will then need to make would be to enable the module for their machine.