### PR TITLE
overlay: workaround mesa 26.0.5 regression

### DIFF
--- a/apple-silicon-support/packages/overlay.nix
+++ b/apple-silicon-support/packages/overlay.nix
@@ -1,4 +1,19 @@
 final: prev: {
   linux-asahi = final.callPackage ./linux-asahi { };
   uboot-asahi = final.callPackage ./uboot-asahi { };
+  mesa =
+    if prev.mesa.version == "26.0.5" then
+      # Workaround for https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/41040
+      prev.mesa.overrideAttrs (old: {
+        version = "26.0.4";
+        src = final.fetchFromGitLab {
+          domain = "gitlab.freedesktop.org";
+          owner = "mesa";
+          repo = "mesa";
+          rev = "mesa-26.0.4";
+          hash = "sha256-gsrqhFCxZRrTbA5MMWARrN6lFVp4Q3D5Jz7MDYbXznY=";
+        };
+      })
+    else
+      prev.mesa;
 }


### PR DESCRIPTION
Use 26.0.4 if nixpkgs brings 26.0.5.
26.0.6 should have the fix, so we only need it if the version is 26.0.5 exactly.

See #447 for details.