### PR TITLE
Support Asahi installer vendorfw format

### DIFF
--- a/apple-silicon-support/modules/peripheral-firmware/default.nix
+++ b/apple-silicon-support/modules/peripheral-firmware/default.nix
@@ -4,78 +4,241 @@
   lib,
   ...
 }:
-{
-  config = lib.mkIf config.hardware.asahi.enable {
-    assertions = lib.mkIf config.hardware.asahi.extractPeripheralFirmware [
+
+let
+  cfg = config.hardware.asahi;
+
+  # Script to extract Asahi firmware
+  # during boot
+  extractAsahiFirmwareInitrdScript = pkgs.writeShellScript "asahi-firmware-extract-initrd" ''
+    set -u
+    mkdir -p /run/asahi-firmware
+
+    # m1n1 may stage vendor firmware directly into the initramfs as /vendorfw.
+    # When that happens, skip ESP discovery and use it directly.
+    if [ -d /vendorfw ] && [ -n "$(ls -A /vendorfw 2>/dev/null)" ]; then
+      echo "Bootloader-staged vendor firmware found in /vendorfw"
+      cp -a /vendorfw/. /run/asahi-firmware/
+      if [ -f /sys/module/firmware_class/parameters/path ]; then
+        echo -n "/run/asahi-firmware" > /sys/module/firmware_class/parameters/path
+        echo "Registered /run/asahi-firmware as kernel firmware search path"
+      fi
+      exit 0
+    fi
+
+    esp_partuuid=""
+    read -r -d ''' esp_partuuid < /proc/device-tree/chosen/asahi,efi-system-partition 2>/dev/null || true
+    if [ -z "$esp_partuuid" ]; then
+      echo "Warning: could not determine Asahi ESP partition UUID"
+      exit 0
+    fi
+
+    esp_dev="/dev/disk/by-partuuid/$esp_partuuid"
+
+    # Wait up to 3 seconds for udev to create the block device symlink
+    i=0
+    while [ $i -lt 30 ]; do
+      if [ -e "$esp_dev" ]; then
+        break
+      fi
+      sleep 0.1
+      i=$((i + 1))
+    done
+    if [ ! -e "$esp_dev" ]; then
+      echo "Warning: ESP block device $esp_dev not found, skipping firmware extraction"
+      exit 0
+    fi
+
+    mkdir -p /tmp/asahi-esp
+    if ! mount -o ro -t vfat "$esp_dev" /tmp/asahi-esp 2>/dev/null; then
+      # Fallback: ESP may already be mounted (e.g. custom initrd config).
+      # Resolve the real backing device and look it up in /proc/mounts.
+      real_dev=""
+      real_dev=$(readlink -f "$esp_dev" 2>/dev/null || true)
+      existing=""
+      if [ -n "$real_dev" ] && [ -r /proc/mounts ]; then
+        while read -r dev mnt _; do
+          if [ "$dev" = "$esp_dev" ] || [ "$dev" = "$real_dev" ]; then
+            existing="$mnt"
+            break
+          fi
+        done < /proc/mounts
+      fi
+      if [ -n "$existing" ] && mount --bind "$existing" /tmp/asahi-esp; then
+        echo "ESP already mounted at $existing, bind-mounting for firmware extraction"
+      else
+        echo "Warning: failed to mount ESP, skipping firmware extraction"
+        rmdir /tmp/asahi-esp 2>/dev/null || true
+        exit 0
+      fi
+    fi
+
+    cleanup() {
+      umount /tmp/asahi-esp 2>/dev/null || true
+      rmdir /tmp/asahi-esp 2>/dev/null || true
+    }
+    trap cleanup EXIT
+
+    echo "Extracting Asahi firmware from ESP..."
+
+    if [ -f /tmp/asahi-esp/vendorfw/firmware.cpio ]; then
+      mkdir -p /tmp/asahi-fwextract
+      (
+        cd /tmp/asahi-fwextract
+        ${pkgs.cpio}/bin/cpio -id --quiet --no-absolute-filenames < /tmp/asahi-esp/vendorfw/firmware.cpio
+      )
+      if [ -d /tmp/asahi-fwextract/vendorfw ]; then
+        cp -a /tmp/asahi-fwextract/vendorfw/. /run/asahi-firmware/
+        echo "Asahi firmware extracted successfully"
+        if [ -f /sys/module/firmware_class/parameters/path ]; then
+          echo -n "/run/asahi-firmware" > /sys/module/firmware_class/parameters/path
+          echo "Registered /run/asahi-firmware as kernel firmware search path"
+        fi
+      else
+        echo "Warning: firmware archive did not contain vendorfw/ directory"
+      fi
+    elif [ -f /tmp/asahi-esp/asahi/all_firmware.tar.gz ]; then
+      echo "Warning: legacy all_firmware.tar.gz found on ESP but boot-time extraction only supports vendorfw/firmware.cpio"
+    else
+      echo "Warning: vendorfw/firmware.cpio not found on ESP"
+    fi
+    exit 0
+  '';
+
+  # Script to extract Asahi firmware
+  # at eval time (not boot-time)
+  extractAsahiFirmwareAtEval =
+    let
+      pkgs' = cfg.pkgs;
+      firmwareDir = cfg.peripheralFirmwareDirectory;
+    in
+    pkgs.runCommand "asahi-peripheral-firmware"
       {
-        assertion = config.hardware.asahi.peripheralFirmwareDirectory != null;
-        message = ''
-          Asahi peripheral firmware extraction is enabled but the firmware
-          location appears incorrect.
-        '';
-      }
-    ];
-
-    hardware.firmware =
-      let
-        pkgs' = config.hardware.asahi.pkgs;
-      in
-      lib.mkIf
-        (
-          (config.hardware.asahi.peripheralFirmwareDirectory != null)
-          && config.hardware.asahi.extractPeripheralFirmware
-        )
-        [
-          (pkgs.stdenv.mkDerivation {
-            name = "asahi-peripheral-firmware";
-
-            nativeBuildInputs = [
-              pkgs'.asahi-fwextract
-              pkgs.cpio
-            ];
-
-            buildCommand = ''
-              mkdir extracted
-              asahi-fwextract ${config.hardware.asahi.peripheralFirmwareDirectory} extracted
-
-              mkdir -p $out/lib/firmware
-              cat extracted/firmware.cpio | cpio -id --quiet --no-absolute-filenames
-              mv vendorfw/* $out/lib/firmware
-            '';
-          })
+        nativeBuildInputs = [
+          pkgs'.asahi-fwextract
+          pkgs.cpio
         ];
-  };
+      }
+      ''
+        mkdir -p $out/lib/firmware
+
+        if [ -f "${firmwareDir}/firmware.cpio" ]; then
+          cpio_src="${firmwareDir}/firmware.cpio"
+
+        elif [ -f "${firmwareDir}/all_firmware.tar.gz" ]; then
+          mkdir extracted
+          asahi-fwextract "${firmwareDir}" extracted
+          cpio_src=extracted/firmware.cpio
+
+        else
+          echo "ERROR: No recognized Asahi firmware format found in ${firmwareDir}" >&2
+          echo "Expected: firmware.cpio (installer 0.8.0+) or all_firmware.tar.gz (legacy)" >&2
+          exit 1
+        fi
+
+        cpio -id --quiet --no-absolute-filenames < "$cpio_src"
+        cp -a vendorfw/. $out/lib/firmware
+      '';
+in
+{
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        assertions = [
+          {
+            assertion = !cfg.extractPeripheralFirmware || cfg.peripheralFirmwareDirectory != null;
+            message = ''
+              Asahi peripheral firmware extraction is enabled but the firmware
+              location appears incorrect.
+            '';
+          }
+        ];
+      }
+
+      (lib.mkIf cfg.extractPeripheralFirmware {
+        hardware.firmware = lib.mkIf (cfg.peripheralFirmwareDirectory != null) [
+          extractAsahiFirmwareAtEval
+        ];
+      })
+
+      (lib.mkIf (!cfg.extractPeripheralFirmware) {
+        # vfat + codepage modules for ESP mounting in initrd
+        boot.initrd.availableKernelModules = [
+          "vfat"
+          "nls_cp437"
+          "nls_iso8859-1"
+        ];
+
+        # Stage 1 systemd service: mount ESP, extract vendorfw, register firmware path.
+        # The script and cpio binary must be present in the initrd.
+        boot.initrd.systemd.storePaths = [
+          pkgs.cpio
+          extractAsahiFirmwareInitrdScript
+        ];
+
+        boot.initrd.systemd.services.asahi-firmware-extract = {
+          description = "Extract Asahi peripheral firmware from ESP";
+          wantedBy = [ "initrd.target" ];
+          after = [ "systemd-udevd.service" ];
+          before = [
+            "systemd-modules-load.service"
+            "initrd-switch-root.target"
+          ];
+          unitConfig.DefaultDependencies = false;
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = extractAsahiFirmwareInitrdScript;
+          };
+        };
+
+        # NixOS's udev activation snippet (nixpkgs:
+        # nixos/modules/services/hardware/udev.nix, the firmware-loading-path
+        # block) unconditionally overwrites
+        # /sys/module/firmware_class/parameters/path with the Nix-store combined
+        # firmware directory. Re-point it at the initrd-extracted firmware so
+        # Wi-Fi/Bluetooth drivers find their blobs. Must run after "udevd" but
+        # before systemd-modules-load triggers driver binds.
+        system.activationScripts.asahi-firmware-path = lib.stringAfter [ "udevd" ] ''
+          if [ -d /run/asahi-firmware ] && [ -e /sys/module/firmware_class/parameters/path ]; then
+            echo -n "/run/asahi-firmware" > /sys/module/firmware_class/parameters/path
+          fi
+        '';
+      })
+    ]
+  );
 
   options.hardware.asahi = {
     extractPeripheralFirmware = lib.mkOption {
       type = lib.types.bool;
-      default = true;
+      default = false;
       description = ''
-        Automatically extract the non-free non-redistributable peripheral
-        firmware necessary for features like Wi-Fi.
+        When enabled, extract the non-free non-redistributable
+        Asahi peripheral firmware into the Nix store at evaluation time.
+
+        Enable this if you are using the legacy <filename>asahi/all_firmware.tar.gz</filename>
+        format or want declarative/offline firmware management.
+
+        The default (disabled) loads firmware from the ESP at boot time, which
+        is the recommended approach and matches upstream Fedora Asahi Linux.
       '';
     };
 
     peripheralFirmwareDirectory = lib.mkOption {
       type = lib.types.nullOr lib.types.path;
 
-      default = lib.findFirst (path: builtins.pathExists (path + "/all_firmware.tar.gz")) null [
-        # path when the system is operating normally
-        /boot/asahi
-        # path when the system is mounted in the installer
-        /mnt/boot/asahi
-      ];
+      default = null;
 
       description = ''
         Path to the directory containing the non-free non-redistributable
-        peripheral firmware necessary for features like Wi-Fi. Ordinarily, this
-        will automatically point to the appropriate location on the ESP. Flake
-        users and those interested in maximum purity will want to copy those
-        files elsewhere and specify this manually.
+        peripheral firmware necessary for features like Wi-Fi.
 
-        Currently, this consists of the files `all-firmware.tar.gz` and
-        `kernelcache*`. The official Asahi Linux installer places these files
-        in the `asahi` directory of the EFI system partition when creating it.
+        This option is only used when <option>extractPeripheralFirmware</option>
+        is enabled. When boot-time loading is used (the default), firmware is read
+        directly from the ESP and this option is ignored.
+
+        For declarative management, copy the firmware files elsewhere (like ./firmware) and
+        specify this path manually.
       '';
     };
   };

--- a/apple-silicon-support/modules/peripheral-firmware/default.nix
+++ b/apple-silicon-support/modules/peripheral-firmware/default.nix
@@ -152,6 +152,9 @@ in
           "nls_iso8859-1"
         ];
 
+        boot.initrd.kernelModules = [ "overlay" ];
+        boot.kernelModules = [ "overlay" ];
+
         # Stage 1 systemd service: mount ESP, extract vendorfw, register firmware path.
         # The script and cpio binary must be present in the initrd.
         boot.initrd.systemd.storePaths = [
@@ -175,16 +178,25 @@ in
           };
         };
 
-        # NixOS's udev activation snippet (nixpkgs:
-        # nixos/modules/services/hardware/udev.nix, the firmware-loading-path
-        # block) unconditionally overwrites
-        # /sys/module/firmware_class/parameters/path with the Nix-store combined
-        # firmware directory. Re-point it at the initrd-extracted firmware so
-        # Wi-Fi/Bluetooth drivers find their blobs. Must run after "udevd" but
-        # before systemd-modules-load triggers driver binds.
-        system.activationScripts.asahi-firmware-path = lib.stringAfter [ "udevd" ] ''
+        # udev activation overwrites the firmware path with the NixOS combined
+        # directory, hiding the Asahi firmware extracted in initrd. Overlay
+        # both so user-declared firmware (hardware.firmware) remains available.
+        # Must run after udevd but before module loading.
+        system.activationScripts.asahi-firmware-path = lib.stringAfter [ "udevd" "modprobe" ] ''
           if [ -d /run/asahi-firmware ] && [ -e /sys/module/firmware_class/parameters/path ]; then
-            echo -n "/run/asahi-firmware" > /sys/module/firmware_class/parameters/path
+            nixos_fw=$(cat /sys/module/firmware_class/parameters/path)
+
+            umount -l /run/firmware-merged 2>/dev/null || true
+            mkdir -p /run/firmware-merged
+
+            # Asahi firmware takes precedence if both sources provide the same path.
+            if [ -n "$nixos_fw" ] && [ -d "$nixos_fw" ] && mount -t overlay overlay -o ro,lowerdir=/run/asahi-firmware:"$nixos_fw" /run/firmware-merged; then
+              echo -n "/run/firmware-merged" > /sys/module/firmware_class/parameters/path
+            else
+              # If overlay fails, keep built-in Wi-Fi/BT working with Asahi firmware.
+              echo "Warning: failed to merge Asahi and NixOS firmware; falling back to Asahi firmware only" >&2
+              echo -n "/run/asahi-firmware" > /sys/module/firmware_class/parameters/path
+            fi
           fi
         '';
       })

--- a/apple-silicon-support/modules/peripheral-firmware/default.nix
+++ b/apple-silicon-support/modules/peripheral-firmware/default.nix
@@ -8,23 +8,10 @@
 let
   cfg = config.hardware.asahi;
 
-  # Script to extract Asahi firmware
-  # during boot
+  # Script to extract Asahi firmware during boot
   extractAsahiFirmwareInitrdScript = pkgs.writeShellScript "asahi-firmware-extract-initrd" ''
     set -u
     mkdir -p /run/asahi-firmware
-
-    # m1n1 may stage vendor firmware directly into the initramfs as /vendorfw.
-    # When that happens, skip ESP discovery and use it directly.
-    if [ -d /vendorfw ] && [ -n "$(ls -A /vendorfw 2>/dev/null)" ]; then
-      echo "Bootloader-staged vendor firmware found in /vendorfw"
-      cp -a /vendorfw/. /run/asahi-firmware/
-      if [ -f /sys/module/firmware_class/parameters/path ]; then
-        echo -n "/run/asahi-firmware" > /sys/module/firmware_class/parameters/path
-        echo "Registered /run/asahi-firmware as kernel firmware search path"
-      fi
-      exit 0
-    fi
 
     esp_partuuid=""
     read -r -d ''' esp_partuuid < /proc/device-tree/chosen/asahi,efi-system-partition 2>/dev/null || true
@@ -109,13 +96,12 @@ let
   # at eval time (not boot-time)
   extractAsahiFirmwareAtEval =
     let
-      pkgs' = cfg.pkgs;
       firmwareDir = cfg.peripheralFirmwareDirectory;
     in
     pkgs.runCommand "asahi-peripheral-firmware"
       {
         nativeBuildInputs = [
-          pkgs'.asahi-fwextract
+          cfg.pkgs.asahi-fwextract
           pkgs.cpio
         ];
       }
@@ -141,27 +127,24 @@ let
       '';
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [ "hardware" "asahi" "extractPeripheralFirmware" ] ''
+      Eval-time firmware extraction is now enabled by setting
+      `hardware.asahi.peripheralFirmwareDirectory` to a path.
+      Leave it as `null` (the default) to load firmware from
+      the ESP at boot time (recommended).
+    '')
+  ];
+
   config = lib.mkIf cfg.enable (
     lib.mkMerge [
       {
-        assertions = [
-          {
-            assertion = !cfg.extractPeripheralFirmware || cfg.peripheralFirmwareDirectory != null;
-            message = ''
-              Asahi peripheral firmware extraction is enabled but the firmware
-              location appears incorrect.
-            '';
-          }
-        ];
-      }
-
-      (lib.mkIf cfg.extractPeripheralFirmware {
         hardware.firmware = lib.mkIf (cfg.peripheralFirmwareDirectory != null) [
           extractAsahiFirmwareAtEval
         ];
-      })
+      }
 
-      (lib.mkIf (!cfg.extractPeripheralFirmware) {
+      (lib.mkIf (cfg.peripheralFirmwareDirectory == null) {
         # vfat + codepage modules for ESP mounting in initrd
         boot.initrd.availableKernelModules = [
           "vfat"
@@ -208,38 +191,24 @@ in
     ]
   );
 
-  options.hardware.asahi = {
-    extractPeripheralFirmware = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        When enabled, extract the non-free non-redistributable
-        Asahi peripheral firmware into the Nix store at evaluation time.
+  options.hardware.asahi.peripheralFirmwareDirectory = lib.mkOption {
+    type = lib.types.nullOr lib.types.path;
 
-        Enable this if you are using the legacy <filename>asahi/all_firmware.tar.gz</filename>
-        format or want declarative/offline firmware management.
+    default = null;
 
-        The default (disabled) loads firmware from the ESP at boot time, which
-        is the recommended approach and matches upstream Fedora Asahi Linux.
-      '';
-    };
+    description = ''
+      Path to a directory containing non-free non-redistributable Asahi
+      peripheral firmware (required for Wi-Fi, Bluetooth, etc.).
 
-    peripheralFirmwareDirectory = lib.mkOption {
-      type = lib.types.nullOr lib.types.path;
+      When set to a path, the firmware is extracted from that directory into
+      the Nix store at evaluation time. Both <filename>firmware.cpio</filename>
+      (modern installer 0.8.0+) and <filename>all_firmware.tar.gz</filename>
+      (legacy) are supported. This is useful for users who want
+      declarative/offline firmware management.
 
-      default = null;
-
-      description = ''
-        Path to the directory containing the non-free non-redistributable
-        peripheral firmware necessary for features like Wi-Fi.
-
-        This option is only used when <option>extractPeripheralFirmware</option>
-        is enabled. When boot-time loading is used (the default), firmware is read
-        directly from the ESP and this option is ignored.
-
-        For declarative management, copy the firmware files elsewhere (like ./firmware) and
-        specify this path manually.
-      '';
-    };
+      When left as <literal>null</literal> (the default), firmware is loaded
+      directly from the EFI System Partition at boot time. This is the
+      recommended approach and matches upstream Fedora Asahi Linux.
+    '';
   };
 }

--- a/apple-silicon-support/modules/peripheral-firmware/default.nix
+++ b/apple-silicon-support/modules/peripheral-firmware/default.nix
@@ -127,24 +127,17 @@ let
       '';
 in
 {
-  imports = [
-    (lib.mkRemovedOptionModule [ "hardware" "asahi" "extractPeripheralFirmware" ] ''
-      Eval-time firmware extraction is now enabled by setting
-      `hardware.asahi.peripheralFirmwareDirectory` to a path.
-      Leave it as `null` (the default) to load firmware from
-      the ESP at boot time (recommended).
-    '')
-  ];
-
   config = lib.mkIf cfg.enable (
     lib.mkMerge [
       {
-        hardware.firmware = lib.mkIf (cfg.peripheralFirmwareDirectory != null) [
-          extractAsahiFirmwareAtEval
-        ];
+        hardware.firmware =
+          lib.mkIf (cfg.extractPeripheralFirmware && cfg.peripheralFirmwareDirectory != null)
+            [
+              extractAsahiFirmwareAtEval
+            ];
       }
 
-      (lib.mkIf (cfg.peripheralFirmwareDirectory == null) {
+      (lib.mkIf (cfg.extractPeripheralFirmware && cfg.peripheralFirmwareDirectory == null) {
         # vfat + codepage modules for ESP mounting in initrd
         boot.initrd.availableKernelModules = [
           "vfat"
@@ -203,24 +196,44 @@ in
     ]
   );
 
-  options.hardware.asahi.peripheralFirmwareDirectory = lib.mkOption {
-    type = lib.types.nullOr lib.types.path;
+  options.hardware.asahi = {
+    extractPeripheralFirmware = lib.mkOption {
+      type = lib.types.bool;
 
-    default = null;
+      default = true;
 
-    description = ''
-      Path to a directory containing non-free non-redistributable Asahi
-      peripheral firmware (required for Wi-Fi, Bluetooth, etc.).
+      description = ''
+        Whether to load non-free non-redistributable Asahi peripheral firmware
+        (required for Wi-Fi, Bluetooth, etc.).
 
-      When set to a path, the firmware is extracted from that directory into
-      the Nix store at evaluation time. Both <filename>firmware.cpio</filename>
-      (modern installer 0.8.0+) and <filename>all_firmware.tar.gz</filename>
-      (legacy) are supported. This is useful for users who want
-      declarative/offline firmware management.
+        When enabled, firmware is loaded from the EFI System Partition at boot
+        time by default, or from <option>hardware.asahi.peripheralFirmwareDirectory</option>
+        when set.
 
-      When left as <literal>null</literal> (the default), firmware is loaded
-      directly from the EFI System Partition at boot time. This is the
-      recommended approach and matches upstream Fedora Asahi Linux.
-    '';
+        Disable this if you want to use the Apple Silicon support module without
+        loading Asahi peripheral firmware.
+      '';
+    };
+
+    peripheralFirmwareDirectory = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+
+      default = null;
+
+      description = ''
+        Path to a directory containing non-free non-redistributable Asahi
+        peripheral firmware (required for Wi-Fi, Bluetooth, etc.).
+
+        When set to a path, the firmware is extracted from that directory into
+        the Nix store at evaluation time. Both <filename>firmware.cpio</filename>
+        (modern installer 0.8.0+) and <filename>all_firmware.tar.gz</filename>
+        (legacy) are supported. This is useful for users who want
+        declarative/offline firmware management.
+
+        When left as <literal>null</literal> (the default), firmware is loaded
+        directly from the EFI System Partition at boot time. This is the
+        recommended approach and matches upstream Fedora Asahi Linux.
+      '';
+    };
   };
 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,10 +18,11 @@ Fedora Asahi Linux.
 - `hardware.asahi.peripheralFirmwareDirectory` now defaults to `null`.
   When unset (the default), firmware is loaded from the ESP at boot time.
   This is the recommended approach.
-- The `hardware.asahi.extractPeripheralFirmware` option has been removed.
-  To use eval-time extraction instead (e.g. for declarative or offline
+- To use eval-time extraction instead (e.g. for declarative or offline
   firmware management), set `hardware.asahi.peripheralFirmwareDirectory`
   to a path containing `firmware.cpio` or `all_firmware.tar.gz`.
+- Set `hardware.asahi.extractPeripheralFirmware = false` to disable all
+  automatic Asahi peripheral firmware loading.
 
 **Action required for existing installations:**
 
@@ -32,6 +33,8 @@ Fedora Asahi Linux.
   no change is required. Consider switching to boot-time loading,
   which is now the recommended default.
 
+- If you explicitly set `hardware.asahi.extractPeripheralFirmware = false`,
+  no change is required. Asahi peripheral firmware will not be loaded.
 
 - If you were relying on the previous default to extract legacy firmware
   (e.g. from `/boot/asahi`), you must take action because boot-time loading

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,36 @@ Among others, the kernel has been updated to 6.18.x, and `apple_dcp` was renamed
 to `appledrm`, so users specifying the `apple_dcp.show_notch=1` kernelparam need to
 change it to `appledrm.show_notch=1`.
 
+### Peripheral firmware loading changes
+
+Peripheral firmware (required for Wi-Fi, Bluetooth, etc.) is now loaded from
+the EFI System Partition at boot time by default, rather than being extracted
+into the Nix store at evaluation time. This aligns with the approach used by
+Fedora Asahi Linux.
+
+- `hardware.asahi.extractPeripheralFirmware` now defaults to `false`.
+- `hardware.asahi.peripheralFirmwareDirectory` now defaults to `null` and
+  must be explicitly set when eval-time extraction is enabled. It is ignored
+  when boot-time firmware loading is used (the default).
+
+**Action required for existing installations:**
+- If your ESP already has the `vendorfw/firmware.cpio` format (Asahi installer
+  0.8.0+), no configuration change is needed. Firmware will be discovered
+  automatically on the next boot.
+- If you have an older installation with the legacy `asahi/all_firmware.tar.gz`
+  format, you must either:
+  1. Re-run the Asahi Linux installer to update the ESP firmware to the new
+     `vendorfw` format (recommended), or
+  2. Explicitly set `hardware.asahi.extractPeripheralFirmware = true` and point
+     `hardware.asahi.peripheralFirmwareDirectory` at the directory containing
+     your legacy firmware files (e.g. `/boot/asahi`).
+
+Users who prefer declarative/offline firmware management can still opt into
+eval-time extraction by setting `hardware.asahi.extractPeripheralFirmware = true`
+and pointing `hardware.asahi.peripheralFirmwareDirectory` at a local copy of
+the firmware. Both the modern `firmware.cpio` format (copy it from
+`/boot/vendorfw`) and the legacy `all_firmware.tar.gz` format are supported.
+
 
 ## 2025-11-18
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,28 +15,35 @@ the EFI System Partition at boot time by default, rather than being extracted
 into the Nix store at evaluation time. This aligns with the approach used by
 Fedora Asahi Linux.
 
-- `hardware.asahi.extractPeripheralFirmware` now defaults to `false`.
-- `hardware.asahi.peripheralFirmwareDirectory` now defaults to `null` and
-  must be explicitly set when eval-time extraction is enabled. It is ignored
-  when boot-time firmware loading is used (the default).
+- `hardware.asahi.peripheralFirmwareDirectory` now defaults to `null`.
+  When unset (the default), firmware is loaded from the ESP at boot time.
+  This is the recommended approach.
+- The `hardware.asahi.extractPeripheralFirmware` option has been removed.
+  To use eval-time extraction instead (e.g. for declarative or offline
+  firmware management), set `hardware.asahi.peripheralFirmwareDirectory`
+  to a path containing `firmware.cpio` or `all_firmware.tar.gz`.
 
 **Action required for existing installations:**
-- If your ESP already has the `vendorfw/firmware.cpio` format (Asahi installer
-  0.8.0+), no configuration change is needed. Firmware will be discovered
-  automatically on the next boot.
-- If you have an older installation with the legacy `asahi/all_firmware.tar.gz`
-  format, you must either:
-  1. Re-run the Asahi Linux installer to update the ESP firmware to the new
-     `vendorfw` format (recommended), or
-  2. Explicitly set `hardware.asahi.extractPeripheralFirmware = true` and point
-     `hardware.asahi.peripheralFirmwareDirectory` at the directory containing
-     your legacy firmware files (e.g. `/boot/asahi`).
 
-Users who prefer declarative/offline firmware management can still opt into
-eval-time extraction by setting `hardware.asahi.extractPeripheralFirmware = true`
-and pointing `hardware.asahi.peripheralFirmwareDirectory` at a local copy of
-the firmware. Both the modern `firmware.cpio` format (copy it from
-`/boot/vendorfw`) and the legacy `all_firmware.tar.gz` format are supported.
+- If your ESP already contains `vendorfw/firmware.cpio` (Asahi installer 0.8.0+),
+  no configuration change is needed.
+
+- If you explicitly set `hardware.asahi.peripheralFirmwareDirectory`,
+  no change is required. Consider switching to boot-time loading,
+  which is now the recommended default.
+
+
+- If you were relying on the previous default to extract legacy firmware
+  (e.g. from `/boot/asahi`), you must take action because boot-time loading
+  does not support the legacy `asahi/all_firmware.tar.gz` format. Either:
+  1. Rebuild your vendor firmware package to switch to boot-time
+     loading (recommended), or
+  2. Explicitly set `hardware.asahi.peripheralFirmwareDirectory` to your
+     legacy firmware directory to continue using eval-time extraction.
+
+To rebuild the vendor firmware package on your ESP, run the Asahi installer
+(`curl https://alx.sh/ | sh`) from macOS recovery and choose
+**"Rebuild vendor firmware package"** when prompted.
 
 
 ## 2025-11-18

--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -256,6 +256,11 @@ Both `firmware.cpio` (from `/boot/vendorfw` on a modern installation) and the le
 
 Keep in mind that if also using flakes, the referenced path can't be outside your flake, so you will need to copy them in.
 
+If you want to use the Apple Silicon support module without loading Asahi peripheral firmware, set:
+```
+  hardware.asahi.extractPeripheralFirmware = false;
+```
+
 If you want to install a desktop environment, you will have to uncomment the option to enable X11 and NetworkManager, then add an option to include your favorite desktop environment. You may also wish to include graphical packages such as `firefox` in `environment.systemPackages`. For example, to install Xfce:
 ```
   # Enable the X11 windowing system.

--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -247,16 +247,14 @@ Various non-free non-redistributable peripheral firmware files are required to u
 
 By default, the Apple Silicon support module now loads peripheral firmware from the ESP at boot time (before any drivers that need it are loaded). This matches the approach used by Fedora Asahi Linux and means the firmware is not imported into the Nix store at evaluation time. It also means there should be no need for any manual firmware management, as in case any more firmware needs to be collected, the Asahi Installer will do it for us, as it does for Fedora.
 
-If you prefer to manage firmware declaratively in your Nix configuration rather than reading from the ESP at boot time, enable eval-time extraction and specify the path manually:
+If you prefer to manage firmware declaratively in your Nix configuration rather than reading from the ESP at boot time, set the firmware path:
 ```
-  # Enable eval-time extraction and specify the path.
-  hardware.asahi.extractPeripheralFirmware = true;
   hardware.asahi.peripheralFirmwareDirectory = ./firmware;
 ```
 
-Both `firmware.cpio` (from `/boot/vendorfw` on a modern installation) and the legacy `all_firmware.tar.gz` format are supported for eval-time extraction. Place the firmware file(s) in the referenced directory.
+Both `firmware.cpio` (from `/boot/vendorfw` on a modern installation) and the legacy `all_firmware.tar.gz` format are supported for eval-time extraction. Point the path to a location where either of the two files reside.
 
-Keep in mind that if also using flakes, the referenced path can't be outside your flake.
+Keep in mind that if also using flakes, the referenced path can't be outside your flake, so you will need to copy them in.
 
 If you want to install a desktop environment, you will have to uncomment the option to enable X11 and NetworkManager, then add an option to include your favorite desktop environment. You may also wish to include graphical packages such as `firefox` in `environment.systemPackages`. For example, to install Xfce:
 ```

--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -243,15 +243,20 @@ Add the `./apple-silicon-support` directory to the imports list and switch off t
 
 The configuration above is the minimum required to produce a bootable system, but you can further edit the file as desired to perform additional configuration. Uncomment the relevant options and change their values as explained in the file. Note that some advertised features may not work properly at this time. Refer to the [NixOS installation manual](https://nixos.org/manual/nixos/stable/index.html#ch-configuration) for further guidance.
 
-Various non-free non-redistributable peripheral firmware files are required to use system hardware like Wi-Fi. The Asahi Linux installer grabs these from macOS and stores them on the EFI system partition when it is created. The NixOS installer loads them from there while booting so that all hardware is available during installation. By default, the Apple Silicon support module will automatically reference the files in the EFI system partition and incorporate them into your configuration to be managed by the normal NixOS mechanisms.
+Various non-free non-redistributable peripheral firmware files are required to use system hardware like Wi-Fi. The Asahi Linux installer grabs these from macOS and stores them on the EFI system partition when it is created. The NixOS installer loads them from there while booting so that all hardware is available during installation.
 
-Currently, the only supported way to update the peripheral firmware files is to destroy and re-create the EFI system partition, so they will not change unexpectedly. If you do not want the impurity of referencing them (or are using flakes where this is prohibited), copy them off the EFI system partition (e.g. on the installation ISO `mkdir -p /mnt/etc/nixos/firmware && cp /mnt/boot/asahi/{all_firmware.tar.gz,kernelcache*} /mnt/etc/nixos/firmware`) and specify this path in your configuration:
+By default, the Apple Silicon support module now loads peripheral firmware from the ESP at boot time (before any drivers that need it are loaded). This matches the approach used by Fedora Asahi Linux and means the firmware is not imported into the Nix store at evaluation time. It also means there should be no need for any manual firmware management, as in case any more firmware needs to be collected, the Asahi Installer will do it for us, as it does for Fedora.
+
+If you prefer to manage firmware declaratively in your Nix configuration rather than reading from the ESP at boot time, enable eval-time extraction and specify the path manually:
 ```
-  # Specify path to peripheral firmware files.
+  # Enable eval-time extraction and specify the path.
+  hardware.asahi.extractPeripheralFirmware = true;
   hardware.asahi.peripheralFirmwareDirectory = ./firmware;
-  # Or disable extraction and management of them completely.
-  # hardware.asahi.extractPeripheralFirmware = false;
 ```
+
+Both `firmware.cpio` (from `/boot/vendorfw` on a modern installation) and the legacy `all_firmware.tar.gz` format are supported for eval-time extraction. Place the firmware file(s) in the referenced directory.
+
+Keep in mind that if also using flakes, the referenced path can't be outside your flake.
 
 If you want to install a desktop environment, you will have to uncomment the option to enable X11 and NetworkManager, then add an option to include your favorite desktop environment. You may also wish to include graphical packages such as `firefox` in `environment.systemPackages`. For example, to install Xfce:
 ```

--- a/iso-configuration/installer-configuration.nix
+++ b/iso-configuration/installer-configuration.nix
@@ -35,56 +35,16 @@
   swapDevices = lib.mkOverride 60 [ ];
   fileSystems = lib.mkOverride 60 config.lib.isoFileSystems;
 
-  boot.postBootCommands =
-    let
-      inherit (config.hardware.asahi.pkgs) asahi-fwextract;
-    in
-    ''
-      for o in $(</proc/cmdline); do
-        case "$o" in
-          live.nixos.passwd=*)
-            set -- $(IFS==; echo $o)
-            echo "nixos:$2" | ${pkgs.shadow}/bin/chpasswd
-            ;;
-        esac
-      done
-
-      echo Extracting Asahi firmware...
-      mkdir -p /tmp/.fwsetup/{esp,extracted}
-
-      mount /dev/disk/by-partuuid/`cat /proc/device-tree/chosen/asahi,efi-system-partition` /tmp/.fwsetup/esp
-
-      if [ -f /tmp/.fwsetup/esp/vendorfw/firmware.cpio ]; then
-        cpio_src=/tmp/.fwsetup/esp/vendorfw/firmware.cpio
-
-      elif [ -d /tmp/.fwsetup/esp/asahi ] && [ -f /tmp/.fwsetup/esp/asahi/all_firmware.tar.gz ]; then
-        ${asahi-fwextract}/bin/asahi-fwextract /tmp/.fwsetup/esp/asahi /tmp/.fwsetup/extracted
-        cpio_src=/tmp/.fwsetup/extracted/firmware.cpio
-
-      else
-        echo "Warning: No Asahi firmware found in ESP. Wi-Fi and ALS may not work."
-        cpio_src=
-      fi
-
-      if [ -n "$cpio_src" ]; then
-        pushd /tmp/.fwsetup/
-        cat "$cpio_src" | ${pkgs.cpio}/bin/cpio -id --quiet --no-absolute-filenames
-        mkdir -p /lib/firmware
-        if [ -d vendorfw ]; then
-          cp -a vendorfw/. /lib/firmware
-        else
-          echo "Warning: firmware archive did not contain vendorfw/ directory"
-        fi
-        popd
-      fi
-
-      umount /tmp/.fwsetup/esp
-      rm -rf /tmp/.fwsetup
-    '';
-
-  # can't legally be incorporated into the installer image
-  # (and is automatically extracted at boot above)
-  hardware.asahi.extractPeripheralFirmware = false;
+  boot.postBootCommands = ''
+    for o in $(</proc/cmdline); do
+      case "$o" in
+        live.nixos.passwd=*)
+          set -- $(IFS==; echo $o)
+          echo "nixos:$2" | ${pkgs.shadow}/bin/chpasswd
+          ;;
+      esac
+    done
+  '';
 
   isoImage.squashfsCompression = "zstd -Xcompression-level 6";
 

--- a/iso-configuration/installer-configuration.nix
+++ b/iso-configuration/installer-configuration.nix
@@ -53,14 +53,32 @@
       mkdir -p /tmp/.fwsetup/{esp,extracted}
 
       mount /dev/disk/by-partuuid/`cat /proc/device-tree/chosen/asahi,efi-system-partition` /tmp/.fwsetup/esp
-      ${asahi-fwextract}/bin/asahi-fwextract /tmp/.fwsetup/esp/asahi /tmp/.fwsetup/extracted
-      umount /tmp/.fwsetup/esp
 
-      pushd /tmp/.fwsetup/
-      cat /tmp/.fwsetup/extracted/firmware.cpio | ${pkgs.cpio}/bin/cpio -id --quiet --no-absolute-filenames
-      mkdir -p /lib/firmware
-      mv vendorfw/* /lib/firmware
-      popd
+      if [ -f /tmp/.fwsetup/esp/vendorfw/firmware.cpio ]; then
+        cpio_src=/tmp/.fwsetup/esp/vendorfw/firmware.cpio
+
+      elif [ -d /tmp/.fwsetup/esp/asahi ] && [ -f /tmp/.fwsetup/esp/asahi/all_firmware.tar.gz ]; then
+        ${asahi-fwextract}/bin/asahi-fwextract /tmp/.fwsetup/esp/asahi /tmp/.fwsetup/extracted
+        cpio_src=/tmp/.fwsetup/extracted/firmware.cpio
+
+      else
+        echo "Warning: No Asahi firmware found in ESP. Wi-Fi and ALS may not work."
+        cpio_src=
+      fi
+
+      if [ -n "$cpio_src" ]; then
+        pushd /tmp/.fwsetup/
+        cat "$cpio_src" | ${pkgs.cpio}/bin/cpio -id --quiet --no-absolute-filenames
+        mkdir -p /lib/firmware
+        if [ -d vendorfw ]; then
+          cp -a vendorfw/. /lib/firmware
+        else
+          echo "Warning: firmware archive did not contain vendorfw/ directory"
+        fi
+        popd
+      fi
+
+      umount /tmp/.fwsetup/esp
       rm -rf /tmp/.fwsetup
     '';
 


### PR DESCRIPTION
Asahi installer moved peripheral firmware from `/boot/asahi` to `/boot/vendorfw` and changed the packaging. I think this was changed in [this commit](https://github.com/AsahiLinux/asahi-installer/commit/ee574521ea00601735c064fd87ca549042734728), but as mentioned in the latest [asahi blog](https://asahilinux.org/2026/04/progress-report-7-0/) the deployed installer hasn't been updated in a while. When running the "Rebuild vendor firmware package" option on the asahi installer, I got this new package format and ran into issues trying to apply the firmware changes.

This branch updates both the runtime firmware module and the installer ISO to handle the new format.

Changes:

• peripheralFirmwareDirectory default now searches /boot/vendorfw first, then falls back to /boot/asahi and the equivalent installer mount paths
• Build scripts and installer postBootCommands auto-detect which format is present and extract accordingly. (Note: I have not tested the installer yet.)

Tested on M1 Pro by pointing at this branch and re-building. I have not tested the installer changes.


Disclaimer: `Kimi K2.6` was used in helping to diagnose the issue and suggesting script changes. I manually reviewed, tested, and made a few teaks to make the code a bit more readable.