### PR TITLE
docs/uefi-standalone: fix invalid networkmanager option

### DIFF
--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -271,7 +271,7 @@ Some keyboard layouts are not detected correctly. On some devices, the \` key is
 `iwd` is recommended for WiFi on most systems:
 ```nix
 # Implicitly enables IWD and disables wpa_supplicant
-networking.networkmanager.backend = "iwd";
+networking.networkmanager.wifi.backend = "iwd";
 ```
 
 If you have a MacBook model that has a [touchbar](https://support.apple.com/guide/mac-help/use-the-touch-bar-mchlbfd5b039/mac), you will also have to add this to your configuration to ensure that graphical sessions render on the main display and not within the touchbar itself:


### PR DESCRIPTION
Fixes: https://github.com/nix-community/nixos-apple-silicon/pull/433