### PR TITLE
linux-asahi: asahi-6.19.14-1 -> asahi-6.19.14-2

### DIFF
--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -26,8 +26,8 @@ let
       src = fetchFromGitHub {
         owner = "AsahiLinux";
         repo = "linux";
-        tag = "asahi-6.19.14-1";
-        hash = "sha256-KabWqdlphJQar9jBi5Vj2lEH5APVbNrl+XpWWUirCKM=";
+        tag = "asahi-6.19.14-2";
+        hash = "sha256-N2ZIiuW6Y61m0E2JWy/Rc71iFFNspdqityxbxG0OJhs=";
       };
 
       kernelPatches = [


### PR DESCRIPTION
> - Dirty Frag fixes backported (taken from
  https://gitlab.com/cki-project/kernel-ark fedora-6.19)