### PR TITLE
linux-asahi: allow user to pass extra arguments to buildLinux

### DIFF
--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -3,61 +3,69 @@
   callPackage,
   linuxPackagesFor,
   _kernelPatches ? [ ],
-}:
+}@args:
 
 let
+  extraArgs = lib.removeAttrs args [
+    "lib"
+    "callPackage"
+    "linuxPackagesFor"
+    "_kernelPatches"
+  ];
+
   linux-asahi-pkg =
     {
       stdenv,
       lib,
       fetchFromGitHub,
-      fetchpatch,
       buildLinux,
       ...
     }:
-    buildLinux rec {
-      inherit stdenv lib;
+    buildLinux (
+      lib.recursiveUpdate rec {
+        inherit stdenv lib;
 
-      pname = "linux-asahi";
-      version = "7.0.13";
-      modDirVersion = version;
-      extraMeta.branch = "7.0";
+        pname = "linux-asahi";
+        version = "7.0.13";
+        modDirVersion = version;
+        extraMeta.branch = "7.0";
 
-      src = fetchFromGitHub {
-        owner = "AsahiLinux";
-        repo = "linux";
-        tag = "asahi-7.0.13-1";
-        hash = "sha256-vXi7c1NWty/I6v1++j/Glnar1DJE6zeUfALZOuhV9fY=";
-      };
+        src = fetchFromGitHub {
+          owner = "AsahiLinux";
+          repo = "linux";
+          tag = "asahi-7.0.13-1";
+          hash = "sha256-vXi7c1NWty/I6v1++j/Glnar1DJE6zeUfALZOuhV9fY=";
+        };
 
-      kernelPatches = [
-        {
-          name = "Asahi config";
-          patch = null;
-          structuredExtraConfig = with lib.kernel; {
-            # Needed for GPU
-            ARM64_16K_PAGES = yes;
+        kernelPatches = [
+          {
+            name = "Asahi config";
+            patch = null;
+            structuredExtraConfig = with lib.kernel; {
+              # Needed for GPU
+              ARM64_16K_PAGES = yes;
 
-            ARM64_MEMORY_MODEL_CONTROL = yes;
-            ARM64_ACTLR_STATE = yes;
+              ARM64_MEMORY_MODEL_CONTROL = yes;
+              ARM64_ACTLR_STATE = yes;
 
-            # Might lead to the machine rebooting if not loaded soon enough
-            APPLE_WATCHDOG = yes;
+              # Might lead to the machine rebooting if not loaded soon enough
+              APPLE_WATCHDOG = yes;
 
-            # Can not be built as a module, defaults to no
-            APPLE_M1_CPU_PMU = yes;
+              # Can not be built as a module, defaults to no
+              APPLE_M1_CPU_PMU = yes;
 
-            # Defaults to 'y', but we want to allow the user to set options in modprobe.d
-            HID_APPLE = module;
+              # Defaults to 'y', but we want to allow the user to set options in modprobe.d
+              HID_APPLE = module;
 
-            APPLE_PMGR_MISC = yes;
-            APPLE_PMGR_PWRSTATE = yes;
-          };
-          features.rust = true;
-        }
-      ]
-      ++ _kernelPatches;
-    };
+              APPLE_PMGR_MISC = yes;
+              APPLE_PMGR_PWRSTATE = yes;
+            };
+            features.rust = true;
+          }
+        ]
+        ++ _kernelPatches;
+      } extraArgs
+    );
 
   linux-asahi = callPackage linux-asahi-pkg { };
 in


### PR DESCRIPTION
without this I couldn't find a way to override things like `enableCommonConfig` or `ignoreConfigErrors` in the kernel package - I'd be happy to use that if there is a way, although this still seems like a more convenient option