### PR TITLE
modules/boot-m1n1: install m1n1 stage 2 via systemd-tmpfiles

### DIFF
--- a/apple-silicon-support/modules/boot-m1n1/default.nix
+++ b/apple-silicon-support/modules/boot-m1n1/default.nix
@@ -33,10 +33,12 @@ let
 in
 {
   config = lib.mkIf config.hardware.asahi.enable {
-    # install m1n1 with the boot loader
-    boot.loader.grub.extraFiles = bootFiles;
-    boot.loader.systemd-boot.extraFiles = bootFiles;
-    boot.loader.limine.additionalFiles = bootFiles;
+    systemd.tmpfiles.rules = [
+      # Remove the old version first so it gets replaced every time
+      "r ${config.boot.loader.efi.efiSysMountPoint}/m1n1/boot.bin"
+      # Copy the new one
+      "C ${config.boot.loader.efi.efiSysMountPoint}/m1n1/boot.bin 0644 root root - ${bootFiles."m1n1/boot.bin"}"
+    ];
 
     # ensure the installer has m1n1 in the image
     system.extraDependencies = lib.mkForce [


### PR DESCRIPTION
*(Edited)*

Description:
Limine sandboxes extraFiles, so the m1n1 binary wasn't being placed where m1n1 stage 1 expects it, and the file wasn't updating on rebuilds. This replaces the bootloader-specific extraFiles logic with systemd.tmpfiles.rules that copy the binary directly to /boot/m1n1/boot.bin, matching the m1n1 User Guide. The copy happens immediately during nixos-rebuild switch, and also at boot.

Changes:
- Removed boot.loader.*.extraFiles lines.
- Added systemd.tmpfiles.rules to manage /m1n1/boot.bin on the ESP.

Testing:
- Deleted the existing m1n1 directory and rebuilt -> file reappeared instantly.
- Rebooted successfully with the new binary.

Fixes #440 