### PR TITLE
Revert "modules/boot-m1n1: install m1n1 stage 2 via systemd-tmpfiles"

### DIFF
--- a/apple-silicon-support/modules/boot-m1n1/default.nix
+++ b/apple-silicon-support/modules/boot-m1n1/default.nix
@@ -33,12 +33,10 @@ let
 in
 {
   config = lib.mkIf config.hardware.asahi.enable {
-    systemd.tmpfiles.rules = [
-      # Remove the old version first so it gets replaced every time
-      "r ${config.boot.loader.efi.efiSysMountPoint}/m1n1/boot.bin"
-      # Copy the new one
-      "C ${config.boot.loader.efi.efiSysMountPoint}/m1n1/boot.bin 0644 root root - ${bootFiles."m1n1/boot.bin"}"
-    ];
+    # install m1n1 with the boot loader
+    boot.loader.grub.extraFiles = bootFiles;
+    boot.loader.systemd-boot.extraFiles = bootFiles;
+    boot.loader.limine.additionalFiles = bootFiles;
 
     # ensure the installer has m1n1 in the image
     system.extraDependencies = lib.mkForce [


### PR DESCRIPTION
Reverts nix-community/nixos-apple-silicon#480

User reported their /boot/m1n1 being nuked without replacement in #asahi irc 