### PR TITLE
gh actions: drop namespacelabs/nscloud-cache-action

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -35,9 +35,6 @@ jobs:
       uses: actions/checkout@v7
       with:
         ref: "${{ matrix.ref }}"
-    - uses: namespacelabs/nscloud-cache-action@v1
-      with:
-        path: ~/.cache/nix
     - name: Install nix
       uses: cachix/install-nix-action@v31
       with:


### PR DESCRIPTION
Looking at https://github.com/namespace-integration-demos/nix-cache-example/blob/main/.github/workflows/demo.yaml, you're supposed to put `path: /nix` in there, not ~/.cache/nix.

Having a cache that maybe contains (stale) data is scary, we really don't want that, at least not if we also don't also keep the rest of that state.