### PR TITLE
peripheral-firmware: use firmware.cpio file instead of all_firmware.tar.gz

### DIFF
--- a/apple-silicon-support/modules/peripheral-firmware/default.nix
+++ b/apple-silicon-support/modules/peripheral-firmware/default.nix
@@ -17,9 +17,6 @@
     ];
 
     hardware.firmware =
-      let
-        pkgs' = config.hardware.asahi.pkgs;
-      in
       lib.mkIf
         (
           (config.hardware.asahi.peripheralFirmwareDirectory != null)
@@ -30,16 +27,13 @@
             name = "asahi-peripheral-firmware";
 
             nativeBuildInputs = [
-              pkgs'.asahi-fwextract
               pkgs.cpio
             ];
 
             buildCommand = ''
-              mkdir extracted
-              asahi-fwextract ${config.hardware.asahi.peripheralFirmwareDirectory} extracted
+              cat ${config.hardware.asahi.peripheralFirmwareDirectory}/firmware.cpio | cpio -id --quiet --no-absolute-filenames
 
               mkdir -p $out/lib/firmware
-              cat extracted/firmware.cpio | cpio -id --quiet --no-absolute-filenames
               mv vendorfw/* $out/lib/firmware
             '';
           })
@@ -52,30 +46,41 @@
       default = true;
       description = ''
         Automatically extract the non-free non-redistributable peripheral
-        firmware necessary for features like Wi-Fi.
+        firmware necessary for features like Wi-Fi, Webcam or brightness sensor.
       '';
     };
 
     peripheralFirmwareDirectory = lib.mkOption {
       type = lib.types.nullOr lib.types.path;
 
-      default = lib.findFirst (path: builtins.pathExists (path + "/all_firmware.tar.gz")) null [
+      default = lib.findFirst (path: builtins.pathExists (path + "/firmware.cpio")) null [
         # path when the system is operating normally
-        /boot/asahi
+        /boot/vendorfw
         # path when the system is mounted in the installer
-        /mnt/boot/asahi
+        /mnt/boot/vendorfw
       ];
 
       description = ''
         Path to the directory containing the non-free non-redistributable
-        peripheral firmware necessary for features like Wi-Fi. Ordinarily, this
-        will automatically point to the appropriate location on the ESP. Flake
-        users and those interested in maximum purity will want to copy those
-        files elsewhere and specify this manually.
+        peripheral firmware necessary for features like Wi-Fi, Webcam or
+        brightness sensor.
 
-        Currently, this consists of the files `all-firmware.tar.gz` and
-        `kernelcache*`. The official Asahi Linux installer places these files
-        in the `asahi` directory of the EFI system partition when creating it.
+        It is shipped in a `vendorfw/firmware.cpio` file on the ESP and put
+        there by the official Asahi Installer.
+
+        The installer can also be invoked from MacOS a second time to re-create
+        and add more firmware on an existing installation.
+
+        This currently defaults to the ESP.
+
+        Flake users, and those interested in maximum purity or building
+        their NixOS config from another machine will want to copy those files
+        elsewhere and specify the path manually.
+
+        In the future, this might be changed to default to loading the
+        `firmware.cpio` from the ESP at boot time, see
+        https://asahilinux.org/docs/platform/open-os-interop/#os-handling for
+        details.
       '';
     };
   };

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,9 +4,34 @@ This file contains important information for each release.
 
 ## 2026-xx-xx
 
-Among others, the kernel has been updated to 6.18.x, and `apple_dcp` was renamed
-to `appledrm`, so users specifying the `apple_dcp.show_notch=1` kernelparam need to
-change it to `appledrm.show_notch=1`.
+Among other kernel updates, the kernel update to 6.18.x included a remame
+of `apple_dcp` to `appledrm`, so users specifying the `apple_dcp.show_notch=1`
+kernelparam need to change it to `appledrm.show_notch=1`.
+
+The kernel update to 7.x also brought support for the ambient light sensor.
+
+Using the sensor also requires extracting more firmware (including
+device-specific calibration data).
+
+This is done through the Asahi Installer. From your MacOS installation:
+
+ - `curl https://alx.sh | sh`
+ - Choose the “Rebuild vendor firmware package” option when prompted
+ - Quit the installer and reboot once this is done
+
+While preparing this, we noticed we were using an internal / deprecated firmware
+format.
+
+The `hardware.firmware.peripheralFirmwareDirectory` module option has been
+changed to default to `/boot/vendorfw`, and to read a `firmware.cpio` file from
+the specified path, rather than (internal) `asahi/all_firmware.tar.gz` firmware
+file we were using so far.
+
+Double-check your ESP partition now contains `vendorfw/firmware.cpio`.
+If you explicitly set this option to a path, make sure it points to the latest
+firmware.
+
+This is to align with https://asahilinux.org/docs/platform/open-os-interop/#linux-specific.
 
 
 ## 2025-11-18
@@ -92,7 +117,7 @@ To upgrade it:
   problems
 * Delete the macOS stub and EFI partitions ONLY, NOT the root partition
   (more info avaiable in the guide's uninstallation section)
-* Reinstall the UEFI environment into the free space using the Asahi installer
+* Reinstall the UEFI environment into the free space using the Asahi Installer
 * Rerun the NixOS installer (more info available in the guide's rescue section)
 
 ## 2025-04-27


### PR DESCRIPTION
This `firmware.cpio` file is where the Asahi Linux installer extracts and updates firmware, and which we should use.

There's also a `firmware.tar` file in the same directory, but it's better to not rely on this as it's not documented in https://asahilinux.org/docs/platform/open-os-interop/#os-handling.

I baked an ISO, booted it over USB and made sure I see wifi devices.

I didn't touch the logic in iso-configuration/installer-configuration.nix, which still uses asahi-fwextract on the ESP contents.

A followup PR will update this to the desired behaviour documented from
the link above, and unify that code to be reusable in both installer and
installed NixOS systems.