### PR TITLE
hardware.asahi: enable iio-sensor-proxy

### DIFF
--- a/apple-silicon-support/modules/default.nix
+++ b/apple-silicon-support/modules/default.nix
@@ -30,6 +30,7 @@
           pkgs;
 
       # 900 is higher priority than mkDefault but lower than just setting
+      hardware.sensor.iio.enable = lib.mkOverride 900 true;
       hardware.graphics.package = lib.mkOverride 900 (
         lib.warnIf
           (lib.versionAtLeast pkgs.mesa.version "25.3" && lib.versionOlder pkgs.mesa.version "25.3.2")

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,7 @@ of `apple_dcp` to `appledrm`, so users specifying the `apple_dcp.show_notch=1`
 kernelparam need to change it to `appledrm.show_notch=1`.
 
 The kernel update to 7.x also brought support for the ambient light sensor.
+To expose it to userspace, we now default to enabling `iio-sensor-proxy`.
 
 Using the sensor also requires extracting more firmware (including
 device-specific calibration data).


### PR DESCRIPTION
This is needed to access the ambient light sensor from userspace.