### PR TITLE
 modules/default.nix: warn if user relies on hardware.asahi.enable defaulting to true

### DIFF
--- a/apple-silicon-support/modules/default.nix
+++ b/apple-silicon-support/modules/default.nix
@@ -1,5 +1,6 @@
 {
   config,
+  options,
   pkgs,
   lib,
   ...
@@ -46,6 +47,17 @@ in
   options.hardware.asahi = {
     enable = lib.mkOption {
       type = lib.types.bool;
+      apply =
+        v:
+        lib.warnIf (options.hardware.asahi.enable.highestPrio == (lib.mkOptionDefault { }).priority) ''
+          You're currently relying on `hardware.asahi.enable` to default to true.
+
+          This will change in the future, to allow including the module unconditionally,
+          but explicitly enable on Asahi machines.
+
+          Please explicitly set `hardware.asahi.enable = true;`, to avoid this
+          suddenly being disabled in the future.
+        '' v;
       default = true;
       description = ''
         Enable the basic Asahi Linux components, such as kernel and boot setup.

--- a/apple-silicon-support/modules/default.nix
+++ b/apple-silicon-support/modules/default.nix
@@ -4,6 +4,10 @@
   lib,
   ...
 }:
+
+let
+  cfg = config.hardware.asahi;
+in
 {
   imports = [
     ./kernel
@@ -12,36 +16,32 @@
     ./sound
   ];
 
-  config =
-    let
-      cfg = config.hardware.asahi;
-    in
-    lib.mkIf cfg.enable {
-      nixpkgs.overlays = lib.mkIf (cfg.overlay != null) (lib.mkBefore [ cfg.overlay ]);
+  config = lib.mkIf cfg.enable {
+    nixpkgs.overlays = lib.mkIf (cfg.overlay != null) (lib.mkBefore [ cfg.overlay ]);
 
-      hardware.asahi.pkgs =
-        if cfg.pkgsSystem != "aarch64-linux" then
-          import (pkgs.path) {
-            crossSystem.system = "aarch64-linux";
-            localSystem.system = cfg.pkgsSystem;
-            overlays = [ cfg.overlay ];
-          }
-        else
-          pkgs;
+    hardware.asahi.pkgs =
+      if cfg.pkgsSystem != "aarch64-linux" then
+        import (pkgs.path) {
+          crossSystem.system = "aarch64-linux";
+          localSystem.system = cfg.pkgsSystem;
+          overlays = [ cfg.overlay ];
+        }
+      else
+        pkgs;
 
-      # 900 is higher priority than mkDefault but lower than just setting
-      hardware.sensor.iio.enable = lib.mkOverride 900 true;
-      hardware.graphics.package = lib.mkOverride 900 (
-        lib.warnIf
-          (lib.versionAtLeast pkgs.mesa.version "25.3" && lib.versionOlder pkgs.mesa.version "25.3.2")
-          ''
-            Mesa 25.3.0 and 25.3.1 are known to cause crashes in Firefox on Asahi
-            GPUs.  Please update to Mesa >= 25.3.2 by updating Nixpkgs.  See
-            https://github.com/nix-community/nixos-apple-silicon/issues/380 for
-            more info.''
-          pkgs.mesa
-      );
-    };
+    # 900 is higher priority than mkDefault but lower than just setting
+    hardware.sensor.iio.enable = lib.mkOverride 900 true;
+    hardware.graphics.package = lib.mkOverride 900 (
+      lib.warnIf
+        (lib.versionAtLeast pkgs.mesa.version "25.3" && lib.versionOlder pkgs.mesa.version "25.3.2")
+        ''
+          Mesa 25.3.0 and 25.3.1 are known to cause crashes in Firefox on Asahi
+          GPUs.  Please update to Mesa >= 25.3.2 by updating Nixpkgs.  See
+          https://github.com/nix-community/nixos-apple-silicon/issues/380 for
+          more info.''
+        pkgs.mesa
+    );
+  };
 
   options.hardware.asahi = {
     enable = lib.mkOption {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -34,6 +34,13 @@ firmware.
 
 This is to align with https://asahilinux.org/docs/platform/open-os-interop/#linux-specific.
 
+We now show a warning if the nixos-apple-silicon modules are imported, but
+`hardware.asahi.enable` (defaulting to true) is not explicitly set.
+This is in preparation for allowing of this module to be included
+unconditionally (and flipping the default to false).
+Explicitly set it to `true` to avoid accidentially getting this disabled in
+the future.
+
 
 ## 2025-11-18
 

--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -236,6 +236,9 @@ Add the `./apple-silicon-support` directory to the imports list and switch off t
       ./apple-silicon-support
     ];
 
+  # Enable basic nixos-apple-silicon support.
+  hardware.asahi.enable = true;
+
   # Use the systemd-boot EFI boot loader.
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = false;

--- a/iso-configuration/installer-configuration.nix
+++ b/iso-configuration/installer-configuration.nix
@@ -64,6 +64,9 @@
       rm -rf /tmp/.fwsetup
     '';
 
+  # Enable basic nixos-apple-silicon support.
+  hardware.asahi.enable = true;
+
   # can't legally be incorporated into the installer image
   # (and is automatically extracted at boot above)
   hardware.asahi.extractPeripheralFirmware = false;


### PR DESCRIPTION
This will change in the future, to allow this module to be included
unconditionally.

To avoid it suddenly disabling asahi bits once that flip happens, show a
warning whenever we rely on the default.
