### PR TITLE
cleanup hardware.asahi.pkgs usages

### DIFF
--- a/apple-silicon-support/modules/boot-m1n1/default.nix
+++ b/apple-silicon-support/modules/boot-m1n1/default.nix
@@ -4,43 +4,46 @@
   lib,
   ...
 }:
-let
-  bootM1n1 = pkgs.m1n1.override (
-    lib.optionalAttrs (config.boot.m1n1CustomLogo != null) {
-      customLogo = config.boot.m1n1CustomLogo;
+{
+  config = lib.mkIf config.hardware.asahi.enable (
+    let
+      bootM1n1 = pkgs.m1n1.override (
+        lib.optionalAttrs (config.boot.m1n1CustomLogo != null) {
+          customLogo = config.boot.m1n1CustomLogo;
+        }
+      );
+
+      bootUBoot = config.hardware.asahi.pkgs.uboot-asahi.override {
+        m1n1 = bootM1n1;
+      };
+
+      bootFiles = {
+        "m1n1/boot.bin" = pkgs.runCommand "boot.bin" { } ''
+          cat ${bootM1n1}/lib/m1n1/m1n1.bin \
+              ${config.boot.kernelPackages.kernel}/dtbs/apple/*.dtb \
+              ${bootUBoot}/u-boot-nodtb.bin.gz \
+              > $out
+          if [ -n "${config.boot.m1n1ExtraOptions}" ]; then
+            echo '${config.boot.m1n1ExtraOptions}' >> $out
+          fi
+        '';
+      };
+
+    in
+    {
+      # install m1n1 with the boot loader
+      boot.loader.grub.extraFiles = bootFiles;
+      boot.loader.systemd-boot.extraFiles = bootFiles;
+      boot.loader.limine.additionalFiles = bootFiles;
+
+      # ensure the installer has m1n1 in the image
+      system.extraDependencies = lib.mkForce [
+        bootM1n1
+        bootUBoot
+      ];
+      system.build.m1n1 = bootFiles."m1n1/boot.bin";
     }
   );
-
-  bootUBoot = config.hardware.asahi.pkgs.uboot-asahi.override {
-    m1n1 = bootM1n1;
-  };
-
-  bootFiles = {
-    "m1n1/boot.bin" = pkgs.runCommand "boot.bin" { } ''
-      cat ${bootM1n1}/lib/m1n1/m1n1.bin \
-          ${config.boot.kernelPackages.kernel}/dtbs/apple/*.dtb \
-          ${bootUBoot}/u-boot-nodtb.bin.gz \
-          > $out
-      if [ -n "${config.boot.m1n1ExtraOptions}" ]; then
-        echo '${config.boot.m1n1ExtraOptions}' >> $out
-      fi
-    '';
-  };
-in
-{
-  config = lib.mkIf config.hardware.asahi.enable {
-    # install m1n1 with the boot loader
-    boot.loader.grub.extraFiles = bootFiles;
-    boot.loader.systemd-boot.extraFiles = bootFiles;
-    boot.loader.limine.additionalFiles = bootFiles;
-
-    # ensure the installer has m1n1 in the image
-    system.extraDependencies = lib.mkForce [
-      bootM1n1
-      bootUBoot
-    ];
-    system.build.m1n1 = bootFiles."m1n1/boot.bin";
-  };
 
   options.boot = {
     m1n1ExtraOptions = lib.mkOption {

--- a/apple-silicon-support/modules/sound/default.nix
+++ b/apple-silicon-support/modules/sound/default.nix
@@ -21,44 +21,40 @@
     let
       cfg = config.hardware.asahi;
     in
-    lib.mkIf (cfg.setupAsahiSound && cfg.enable) (
-      lib.mkMerge [
-        {
-          # can't be used by Asahi sound infrastructure
-          services.pulseaudio.enable = false;
-          # enable pipewire to run real-time and avoid audible glitches
-          security.rtkit.enable = true;
-          # set up pipewire with the supported capabilities (instead of pulseaudio)
-          # and asahi-audio configs and plugins
-          services.pipewire = {
-            enable = true;
-            alsa.enable = true;
-            pulse.enable = true;
+    lib.mkIf (cfg.enable && cfg.setupAsahiSound) {
+      # can't be used by Asahi sound infrastructure
+      services.pulseaudio.enable = false;
+      # enable pipewire to run real-time and avoid audible glitches
+      security.rtkit.enable = true;
+      # set up pipewire with the supported capabilities (instead of pulseaudio)
+      # and asahi-audio configs and plugins
+      services.pipewire = {
+        enable = true;
+        alsa.enable = true;
+        pulse.enable = true;
 
-            configPackages = [ pkgs.asahi-audio ];
+        configPackages = [ pkgs.asahi-audio ];
 
-            wireplumber = {
-              enable = true;
+        wireplumber = {
+          enable = true;
 
-              configPackages = [ pkgs.asahi-audio ];
-            };
-          };
+          configPackages = [ pkgs.asahi-audio ];
+        };
+      };
 
-          # set up enivronment so that UCM configs are used as well
-          environment.variables.ALSA_CONFIG_UCM2 = "${pkgs.alsa-ucm-conf-asahi}/share/alsa/ucm2";
-          systemd.user.services.pipewire.environment.ALSA_CONFIG_UCM2 =
-            config.environment.variables.ALSA_CONFIG_UCM2;
-          systemd.user.services.wireplumber.environment.ALSA_CONFIG_UCM2 =
-            config.environment.variables.ALSA_CONFIG_UCM2;
-          systemd.services.pipewire.environment.ALSA_CONFIG_UCM2 =
-            config.environment.variables.ALSA_CONFIG_UCM2;
-          systemd.services.wireplumber.environment.ALSA_CONFIG_UCM2 =
-            config.environment.variables.ALSA_CONFIG_UCM2;
+      # set up enivronment so that UCM configs are used as well
+      environment.variables.ALSA_CONFIG_UCM2 = "${pkgs.alsa-ucm-conf-asahi}/share/alsa/ucm2";
+      systemd.user.services.pipewire.environment.ALSA_CONFIG_UCM2 =
+        config.environment.variables.ALSA_CONFIG_UCM2;
+      systemd.user.services.wireplumber.environment.ALSA_CONFIG_UCM2 =
+        config.environment.variables.ALSA_CONFIG_UCM2;
+      systemd.services.pipewire.environment.ALSA_CONFIG_UCM2 =
+        config.environment.variables.ALSA_CONFIG_UCM2;
+      systemd.services.wireplumber.environment.ALSA_CONFIG_UCM2 =
+        config.environment.variables.ALSA_CONFIG_UCM2;
 
-          # enable speakersafetyd to protect speakers
-          systemd.packages = [ pkgs.speakersafetyd ];
-          services.udev.packages = [ pkgs.speakersafetyd ];
-        }
-      ]
-    );
+      # enable speakersafetyd to protect speakers
+      systemd.packages = [ pkgs.speakersafetyd ];
+      services.udev.packages = [ pkgs.speakersafetyd ];
+    };
 }


### PR DESCRIPTION
`asahi-fwextract` and `m1n1` live in nixpkgs now, no need to pull in our custom pkgs instance.

Make sure the remaining usages are inside `cfg.enabled` blocks, fixing #500.