### PR TITLE
docs/uefi-standalone: fix doubled word in proxyclient section

### DIFF
--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -72,7 +72,7 @@ $ nix-shell -p python3Packages.{construct,pyserial} # Get dependencies for using
 $ make ARCH=aarch64-unknown-linux-gnu- CHAINLOADING=1 [...]
 ```
 
-To use some of the proxyclient features on on x86\_64, you'll need to adjust the cross-compilation prefix to match the targetPrefix used in Nixpkgs:
+To use some of the proxyclient features on x86\_64, you'll need to adjust the cross-compilation prefix to match the targetPrefix used in Nixpkgs:
 
 Replace `aarch64-linux-gnu-` with `aarch64-unknown-linux-gnu-` in `proxyclient/m1n1/toolchain.py`.
 


### PR DESCRIPTION
Remove the duplicated "on" in the sentence describing proxyclient usage on x86_64.

Before: "To use some of the proxyclient features on on x86\_64"
After:  "To use some of the proxyclient features on x86\_64"