### PR TITLE
peripheral-firmware: show more helpful error message if firmware.cpio is missing

### DIFF
--- a/apple-silicon-support/modules/peripheral-firmware/default.nix
+++ b/apple-silicon-support/modules/peripheral-firmware/default.nix
@@ -31,7 +31,12 @@
             ];
 
             buildCommand = ''
-              cat ${config.hardware.asahi.peripheralFirmwareDirectory}/firmware.cpio | cpio -id --quiet --no-absolute-filenames
+              f=${config.hardware.asahi.peripheralFirmwareDirectory}/firmware.cpio
+              if [ ! -f $f ]; then
+                echo "firmware.cpio missing from peripheralFirmwareDirectory!"
+                exit 1
+              fi
+              cat $f | cpio -id --quiet --no-absolute-filenames
 
               mkdir -p $out/lib/firmware
               mv vendorfw/* $out/lib/firmware


### PR DESCRIPTION
"cpio: premature end of archive" is not a too helpful error message, fix that.