### PR TITLE
modules/boot-m1n1: don't pull m1n1 from hardware.asahi.pkgs

### DIFF
--- a/apple-silicon-support/modules/boot-m1n1/default.nix
+++ b/apple-silicon-support/modules/boot-m1n1/default.nix
@@ -5,17 +5,13 @@
   ...
 }:
 let
-  pkgs' = config.hardware.asahi.pkgs;
+  bootM1n1 = pkgs.m1n1.override (
+    lib.optionalAttrs (config.boot.m1n1CustomLogo != null) {
+      customLogo = config.boot.m1n1CustomLogo;
+    }
+  );
 
-  bootM1n1 =
-    if (config.boot.m1n1CustomLogo != null) then
-      pkgs'.m1n1.override {
-        customLogo = config.boot.m1n1CustomLogo;
-      }
-    else
-      pkgs'.m1n1;
-
-  bootUBoot = pkgs'.uboot-asahi.override {
+  bootUBoot = config.hardware.asahi.pkgs.uboot-asahi.override {
     m1n1 = bootM1n1;
   };
 


### PR DESCRIPTION
m1n1 lives in nixpkgs. The asahi u-boot still needs to be pulled from there.