### PR TITLE
installer-configuration.nix: stop using hardware.asahi.pkgs

### DIFF
--- a/iso-configuration/installer-configuration.nix
+++ b/iso-configuration/installer-configuration.nix
@@ -35,34 +35,30 @@
   swapDevices = lib.mkOverride 60 [ ];
   fileSystems = lib.mkOverride 60 config.lib.isoFileSystems;
 
-  boot.postBootCommands =
-    let
-      inherit (config.hardware.asahi.pkgs) asahi-fwextract;
-    in
-    ''
-      for o in $(</proc/cmdline); do
-        case "$o" in
-          live.nixos.passwd=*)
-            set -- $(IFS==; echo $o)
-            echo "nixos:$2" | ${pkgs.shadow}/bin/chpasswd
-            ;;
-        esac
-      done
+  boot.postBootCommands = ''
+    for o in $(</proc/cmdline); do
+      case "$o" in
+        live.nixos.passwd=*)
+          set -- $(IFS==; echo $o)
+          echo "nixos:$2" | ${pkgs.shadow}/bin/chpasswd
+          ;;
+      esac
+    done
 
-      echo Extracting Asahi firmware...
-      mkdir -p /tmp/.fwsetup/{esp,extracted}
+    echo Extracting Asahi firmware...
+    mkdir -p /tmp/.fwsetup/{esp,extracted}
 
-      mount /dev/disk/by-partuuid/`cat /proc/device-tree/chosen/asahi,efi-system-partition` /tmp/.fwsetup/esp
-      ${asahi-fwextract}/bin/asahi-fwextract /tmp/.fwsetup/esp/asahi /tmp/.fwsetup/extracted
-      umount /tmp/.fwsetup/esp
+    mount /dev/disk/by-partuuid/`cat /proc/device-tree/chosen/asahi,efi-system-partition` /tmp/.fwsetup/esp
+    ${pkgs.asahi-fwextract}/bin/asahi-fwextract /tmp/.fwsetup/esp/asahi /tmp/.fwsetup/extracted
+    umount /tmp/.fwsetup/esp
 
-      pushd /tmp/.fwsetup/
-      cat /tmp/.fwsetup/extracted/firmware.cpio | ${pkgs.cpio}/bin/cpio -id --quiet --no-absolute-filenames
-      mkdir -p /lib/firmware
-      mv vendorfw/* /lib/firmware
-      popd
-      rm -rf /tmp/.fwsetup
-    '';
+    pushd /tmp/.fwsetup/
+    cat /tmp/.fwsetup/extracted/firmware.cpio | ${pkgs.cpio}/bin/cpio -id --quiet --no-absolute-filenames
+    mkdir -p /lib/firmware
+    mv vendorfw/* /lib/firmware
+    popd
+    rm -rf /tmp/.fwsetup
+  '';
 
   # Enable basic nixos-apple-silicon support.
   hardware.asahi.enable = true;


### PR DESCRIPTION
asahi-fwextract lives in nixpkgs, so we don't need to pull it from asahi.pkgs anymore.

Unrelated, we shouldn't be using asahi-fwextract here, but instead pull firmware.cpio from the ESP as documented in https://asahilinux.org/docs/platform/open-os-interop/#linux-specific, but that's out of scope for this commit.