### PR TITLE
modules/default.nix: create notch enable option

### DIFF
--- a/apple-silicon-support/modules/default.nix
+++ b/apple-silicon-support/modules/default.nix
@@ -30,6 +30,8 @@ in
       else
         pkgs;
 
+    boot.kernelParams = lib.mkIf cfg.notch.enable [ "appledrm.show_notch=1" ];
+
     # 900 is higher priority than mkDefault but lower than just setting
     hardware.sensor.iio.enable = lib.mkOverride 900 true;
   };
@@ -86,6 +88,14 @@ in
       defaultText = "overlay provided with the module";
       description = ''
         The nixpkgs overlay for asahi packages.
+      '';
+    };
+
+    notch.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Extends the screen area into the notch on MacBooks.
       '';
     };
   };

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,11 @@
 
 This file contains important information for each release.
 
+## 2026-xx-xx
+
+The `hardware.asahi.notch.enable` is avaliable as a option. This option is
+equivalent to the `appledrm.show_notch=1` kernelparam.
+
 ## 2026-07-30
 
 Among other kernel updates, the kernel update to 6.18.x included a remame


### PR DESCRIPTION
When the notch option changed, I saw people on the subreddit, as well as here (#417) saying that the notch doesn't work. Perhaps creating an option that enables the notch for users is warranted?

LMK if this doesn't fit this repo, the description needs changing, or the option needs to be moved to a different submodule (i.e. kernel).