### PR TITLE
modules/default.nix: drop mesa version warning

### DIFF
--- a/apple-silicon-support/modules/default.nix
+++ b/apple-silicon-support/modules/default.nix
@@ -32,16 +32,6 @@ in
 
     # 900 is higher priority than mkDefault but lower than just setting
     hardware.sensor.iio.enable = lib.mkOverride 900 true;
-    hardware.graphics.package = lib.mkOverride 900 (
-      lib.warnIf
-        (lib.versionAtLeast pkgs.mesa.version "25.3" && lib.versionOlder pkgs.mesa.version "25.3.2")
-        ''
-          Mesa 25.3.0 and 25.3.1 are known to cause crashes in Firefox on Asahi
-          GPUs.  Please update to Mesa >= 25.3.2 by updating Nixpkgs.  See
-          https://github.com/nix-community/nixos-apple-silicon/issues/380 for
-          more info.''
-        pkgs.mesa
-    );
   };
 
   options.hardware.asahi = {


### PR DESCRIPTION
Both nixpkgs stable and unstable are way past this version, no need to warn anymore.