### PR TITLE
docs/uefi-standalone: update boot instructions

### DIFF
--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -146,20 +146,21 @@ If everything went well, you will restart into U-Boot with the Asahi Linux and U
 
 Shut down the machine fully. Connect the flash drive with the installer ISO to a USB port. If not using Wi-Fi, connect the Ethernet cable to the network port or adapter as well.
 
-Start the Mac, and U-Boot should start booting from the USB drive automatically. If you've already installed something to the internal NVMe drive, U-Boot will try to boot it first. To instead boot from USB, hit a key to stop autoboot when prompted, then run the command `bootmenu` and select the `usb 0` entry. If no entries are available, exit and use `bootmenu -e` instead. If this command is not available, instead use `setenv boot_targets "usb" ; setenv bootmeths "efi" ; boot`. GRUB will start, then the NixOS installer after a short delay (the default GRUB option is fine).
+Start the Mac, and U-Boot should start booting from the USB drive automatically. If you've already installed something to the internal NVMe drive, U-Boot might try to boot it first.
+To instead boot from USB:
+ - Hit a key to stop autoboot when prompted
+ - Run the command `eficonfig`
+ - Select "Change Boot Order", ensure `usb 0` is on the top (you can use the `+` key to move it to the top).
+ - "Save" boot order, "Quit" `eficonfig`.
+ - Run the `boot` command.
+
+GRUB will start, then the NixOS installer after a short delay (the default GRUB option is fine).
 
 <details>
-  <summary>If "mounting `/dev/root` on `/mnt-root/iso` failed: No such file or directory" during boot…</summary>
+  <summary>If `/dev/disk/by-label/nixos-xx.yy-aarch64` does not mount…</summary>
   
   1. Was the ISO transferred to your flash drive correctly as described above? `dd` is the only correct way to do this. The ISO must be transferred to the drive block device itself, not a partition on the drive.
-  2. There is sometimes a [race condition](https://github.com/nix-community/nixos-apple-silicon/issues/60) which causes booting to fail. Reboot the machine and try again.
-  3. Some flash drives have quirks. Try a different drive, or use the following steps:
-
-      1. Attempt to start the installer normally
-      1. When the boot fails and you are prompted, hit i to start a shell
-      1. Unplug your flash drive, plug it into a different port, then wait 30 seconds
-      1. Run the command `mount -t iso9660 /dev/root /mnt-root/iso`
-      1. Exit the shell by running `exit` to continue the boot process
+  2. Some flash drives have quirks. Try replugging the USB stick if you're already waiting for 30 seconds.
 </details>
 
 You will get a console prompt once booting completes. Run the command `sudo su` to get a root prompt in the installer. If the console font is too small, run the command `setfont ter-v32n` to increase the size.


### PR DESCRIPTION
Suggest the more graphical and intuitive `eficonfig` tool to select `usb 0`.

Update the help when the root volume doesn't mount. With systemd in initrd, we can simply replug the usb stick if that happens and it'll likely recover.