### PR TITLE
release 2026-07-30

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,7 +2,7 @@
 
 This file contains important information for each release.
 
-## 2026-xx-xx
+## 2026-07-30
 
 Among other kernel updates, the kernel update to 6.18.x included a remame
 of `apple_dcp` to `appledrm`, so users specifying the `apple_dcp.show_notch=1`


### PR DESCRIPTION
Tested according to `docs/release-process.md`.

Installing via the cross installer didn't work, as I ran out of disk space trying to compile the kernel, but then resuming the install with the native-built aarch64-linux image used the kernel shipped with the installation image (so it picks it up from the installation medium).

We should probably document that you need plenty of memory to be able to build your own kernel when coming from the cross image, but I don't consider this a blocker for the release, as people likely use the native image or compile their own flavor natively.

I tested wifi in the installer image (via `nmtui`), and installed a GNOME variant. ALS, Camera, WebGL and speaker was tested to work.